### PR TITLE
Fix broken links in checklist - replace "\" (which was being converted to "%5C" with "/" as separator

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -27,51 +27,51 @@ regular scheduled basis.
 
 | # ▴ | Title | Description | Topic | Essential |
 |---|---|---|---|---|
-| 0010 | [Automate your SAS Viya Deployment Process](tasks\automate_environment_creation.md) | Automate the process of creating and configuring your SAS Viya deployment | Kubernetes & IT Admin | - |
-| 0020 | [Install the SAS Viya CLI](tasks\install_sas_viya_cli.md) | Ensure you have installed the sas-viya cli and its plugins. | Kubernetes & IT Admin | - |
-| 0030 | [Develop an update plan](tasks\develop_update_plan.md) | Develop an update plan: outline tasks required before, during and after an update | Kubernetes & IT Admin | Yes |
-| 0040 | [Maintain a Secure Password Database](tasks\maintain_password_database.md) | Maintain a secure and encrypted password-protected password database using an appropriate software tool or service | Kubernetes & IT Admin | - |
-| 0050 | [Update TLS certificates](tasks\encryption_with_public_ca_signed_tls_certificates.md) | Generate new or renew expiring TLS certificates used for encryption of data in transit. | Kubernetes & IT Admin | - |
-| 0060 | [Load POSIX attributes](tasks\load_posix_attributes.md) | Load POSIX attributes for identities when attributes are not returned from the authentication provider | Kubernetes & IT Admin | - |
-| 0070 | [Create and Configure User home-directories](tasks\createandconfigure_user_homedirs.md) | Create and configure user-home directories | Kubernetes & IT Admin | - |
-| 0080 | [Ensure You Have Provided Sufficient Storage for Path-Based Caslibs](tasks\ensure_storage_for_caslibs.md) | Ensure you have provided sufficient filesystem storage of an appropriate type for path-based caslibs. | Kubernetes & IT Admin | - |
-| 0090 | [Define a Process for Updating External Credentials](tasks\process_for_updating_external_credentials.md) | Define a when and how you will update credentials that are stored in SAS Viya for external systems such as databases, when they change | Kubernetes & IT Admin | - |
-| 0100 | [Know when to renew your OIDC client secret](tasks\when_to_renew_oidc_client_secret.md) | Open ID Connect uses expiring client secrets with a maximum lifetime of 2 years. If your SAS Viya deployment is configured to use OIDC, ensure that you know when this client secret expires so that you can renew it before it does. | Kubernetes & IT Admin | - |
-| 0110 | [Configure Open Source Integration](tasks\configure_open_source_integration.md) | Configure open source integration | Kubernetes & IT Admin | - |
-| 0120 | [Review Tuning Recommendations](tasks\tuning_recommendations.md) | Review SAS Viya platform tuning recommendations and apply as needed | Kubernetes & IT Admin | - |
-| 0130 | [Configure CORS and CSRF settings](tasks\configure_cors_and_csrf.md) | Configure the SAS Viya platform's Cross-Origin Resource Sharing (CORS) and Cross-Site Request Forgery (CSRF) settings for deployments behind a DNS alias or proxy, and for SAS Visual Analytics | Kubernetes & IT Admin | - |
-| 0140 | [Service Level Agreement](tasks\sla.md) | For enterprise-scale deployments, define a Service Level Agreement (SLA) | Organization & Governance | - |
-| 0150 | [Define your organizationâ€™s SAS support team structure, roles, and responsibilities](tasks\define_org_support_structure.md) | Define your organizationâ€™s SAS support team structure, roles, and responsibilities | Organization & Governance | - |
-| 0160 | [Premium Support](tasks\premium_support.md) | Consider whether you require premium or customized support for your SAS deployment | Organization & Governance | - |
-| 0170 | [Security Policy](tasks\security_policy.md) | Write and maintain a security policy that covers the SAS Viya deployment | Organization & Governance | - |
-| 0180 | [Authorization Model](tasks\authorization_model.md) | Write and maintain a security model or an authorization model | Organization & Governance | Yes |
-| 0190 | [Select Log & Metric Monitoring and Alerting Solution](tasks\select_monitoring_solution.md) | Choose a log and metric monitoring and alerting solution | Observability | - |
-| 0200 | [Set Up Monitoring and Alerting](tasks\observability_monitoring_and_alerting.md) | Learn how to deploy, update and use either SAS Viya Monitoring for Kubernetes or a cloud provider's observability tools to leverage logging, monitoring and alerting capabilties in your Viya platform. | Observability | Yes |
-| 0210 | [Understand how to Check the Status of Services](tasks\how_to_check_service_status.md) | Ensure you know how to check the status of all SAS Viya services ad hoc at any time | Observability | - |
-| 0220 | [Configure audit record archival](tasks\audit_record_archival.md) | Configure and schedule the archiving of SAS Viya audit records. | Observability | - |
-| 0230 | [Enable job to purge archived audit records](tasks\purge_archived_audit_records.md) | Enable the routine purging of archived audit records from the archive location (PV) | Observability | - |
-| 0240 | [Validate your SAS Viya Deployment](tasks\validate_deployment.md) | Define a set of tests to validate that your SAS Viya deployment is functioning correctly | SAS Administration | Yes |
-| 0250 | [Define a backup and restore strategy](tasks\backup_and_restore.md) | Define a backup and restore strategy | SAS Administration | Yes |
-| 0260 | [Know how to Contact SAS Technical Support for Help](tasks\contact_SAS_technical_support.md) | Ensure all SAS platform administration staff know how to contact SAS Technical Support for help | SAS Administration | - |
-| 0270 | [Identify Components of SAS and Third-Party Software](tasks\identify_viya_components.md) | Ensure you can identify the components of SAS and third-party software that make up SAS Viya | SAS Administration | - |
-| 0280 | [Decide approach to applying updates](tasks\decide_update_approach.md) | Decide how and when your SAS Viya software will be updated | SAS Administration | - |
-| 0290 | [Configure SAS Studio Preferences](tasks\configure_sas_studio_preferences.md) | Configure SAS Studio Preferences | SAS Administration | - |
-| 0300 | [Define a Process for Onboarding and Offboarding Users](tasks\process_for_onboarding_and_offboarding_users.md) | Document any steps that must be performed when new users are onboarded and offboarded | SAS Administration | Yes |
-| 0310 | [Secure the sasboot password](tasks\secure_sasboot_password.md) | Disable the sasboot password reset feature after you have finished setting up identities and initial administrators | SAS Administration | - |
-| 0320 | [Secure Default Caslibs, especially the Public Caslib](tasks\secure_default_caslibs.md) | Review and change default access controls on default CAS libraries | CAS | - |
-| 0330 | [Consider relocating CAS_DISK_CACHE](tasks\relocate_cas_disk_cache.md) | Relocate the CAS_DISK_CACHE for CAS servers | CAS | - |
-| 0340 | [Configure CAS Allowlist](tasks\configure_cas_allowlist.md) | Configure CAS allowlist for user-defined CAS libraries | CAS | Yes |
-| 0350 | [Configure External Access to CAS](tasks\configure_cas_external_access.md) | Configure access to CAS from outside your SAS Viya deployment | CAS | - |
-| 0360 | [Set location for SAS Work and other Programming Run-Time Temporary Files](tasks\move_sas_work_and_spre_temporary_files_location.md) | Move SAS Work and other Programming Run-Time Temporary Files to a better location than the default | SAS Programming Run-time | - |
-| 0370 | [Configure Common Programming Run-Time Autoexec Statements](tasks\common_programming_run-time_options.md) | Configure statements in SAS Programming Run-Time Autoexec code blocks, to set commonly used SAS options for macro programming, performance tuning, use of mail servers and pre-assigning SAS libraries. | SAS Programming Run-time | Yes |
-| 0380 | [Modify Launcher and SAS Programming Run-Time Server Contexts](tasks\modify_programming_launcher_server_contexts.md) | Modify Launcher and Server contexts for SAS Compute Server, SAS Connect Server and SAS Batch Server | SAS Programming Run-time | - |
-| 0390 | [Define Library Connection Data Sources as a Resource in SAS Programming Run-Time Contexts](tasks\manage_connections_to_data_sources.md) | Compute, Connect and Batch contexts can be associated with Required Resources, the first of which is a Library Connection. | SAS Programming Run-time | - |
-| 0400 | [Configure lockdown for SAS Programming run-time servers](tasks\configure_lockdown.md) | Configure lockdown for SAS Programming Run-Time servers | SAS Programming Run-time | - |
-| 0410 | [Configure Programming Allowlist](tasks\configure_programming_allowlist.md) | Configure SAS Programming Run-Time for user-defined paths | SAS Programming Run-time | - |
-| 0420 | [Configure umask for SAS Programmning run-time servers](tasks\configure_programming_run-time_umask.md) | Configure umask to e.g. 0002 for SAS Programming Run-Time servers, so that files created by users (including datasets in path-based libraries) are read-write for members of the user's primary POSIX group | SAS Programming Run-time | - |
-| 0430 | [Set User Process Limit](tasks\set_user_process_limit.md) | Set the maximum number of launched compute, connect or batch programming run-time pods each user may run simultaneously | SAS Programming Run-time | - |
-| 0440 | [Tune the Programming Run-Time](tasks\tune_programming_run-time.md) | Tune the SAS Viya Platform Programming Run-time for better performance with your workload | SAS Programming Run-time | - |
-| 0450 | [Design and Maintain a Schedule of SAS Administration Housekeeping Activities](tasks\maintain_housekeeping_schedule.md) | Design and maintain a schedule of SAS Viya platform administration housekeeping activities, specifying when regular tasks should be performed. | SAS Administration | Yes |
+| 0010 | [Automate your SAS Viya Deployment Process](tasks/automate_environment_creation.md) | Automate the process of creating and configuring your SAS Viya deployment | Kubernetes & IT Admin | - |
+| 0020 | [Install the SAS Viya CLI](tasks/install_sas_viya_cli.md) | Ensure you have installed the sas-viya cli and its plugins. | Kubernetes & IT Admin | - |
+| 0030 | [Develop an update plan](tasks/develop_update_plan.md) | Develop an update plan: outline tasks required before, during and after an update | Kubernetes & IT Admin | Yes |
+| 0040 | [Maintain a Secure Password Database](tasks/maintain_password_database.md) | Maintain a secure and encrypted password-protected password database using an appropriate software tool or service | Kubernetes & IT Admin | - |
+| 0050 | [Update TLS certificates](tasks/encryption_with_public_ca_signed_tls_certificates.md) | Generate new or renew expiring TLS certificates used for encryption of data in transit. | Kubernetes & IT Admin | - |
+| 0060 | [Load POSIX attributes](tasks/load_posix_attributes.md) | Load POSIX attributes for identities when attributes are not returned from the authentication provider | Kubernetes & IT Admin | - |
+| 0070 | [Create and Configure User home-directories](tasks/createandconfigure_user_homedirs.md) | Create and configure user-home directories | Kubernetes & IT Admin | - |
+| 0080 | [Ensure You Have Provided Sufficient Storage for Path-Based Caslibs](tasks/ensure_storage_for_caslibs.md) | Ensure you have provided sufficient filesystem storage of an appropriate type for path-based caslibs. | Kubernetes & IT Admin | - |
+| 0090 | [Define a Process for Updating External Credentials](tasks/process_for_updating_external_credentials.md) | Define a when and how you will update credentials that are stored in SAS Viya for external systems such as databases, when they change | Kubernetes & IT Admin | - |
+| 0100 | [Know when to renew your OIDC client secret](tasks/when_to_renew_oidc_client_secret.md) | Open ID Connect uses expiring client secrets with a maximum lifetime of 2 years. If your SAS Viya deployment is configured to use OIDC, ensure that you know when this client secret expires so that you can renew it before it does. | Kubernetes & IT Admin | - |
+| 0110 | [Configure Open Source Integration](tasks/configure_open_source_integration.md) | Configure open source integration | Kubernetes & IT Admin | - |
+| 0120 | [Review Tuning Recommendations](tasks/tuning_recommendations.md) | Review SAS Viya platform tuning recommendations and apply as needed | Kubernetes & IT Admin | - |
+| 0130 | [Configure CORS and CSRF settings](tasks/configure_cors_and_csrf.md) | Configure the SAS Viya platform's Cross-Origin Resource Sharing (CORS) and Cross-Site Request Forgery (CSRF) settings for deployments behind a DNS alias or proxy, and for SAS Visual Analytics | Kubernetes & IT Admin | - |
+| 0140 | [Service Level Agreement](tasks/sla.md) | For enterprise-scale deployments, define a Service Level Agreement (SLA) | Organization & Governance | - |
+| 0150 | [Define your organizationâ€™s SAS support team structure, roles, and responsibilities](tasks/define_org_support_structure.md) | Define your organizationâ€™s SAS support team structure, roles, and responsibilities | Organization & Governance | - |
+| 0160 | [Premium Support](tasks/premium_support.md) | Consider whether you require premium or customized support for your SAS deployment | Organization & Governance | - |
+| 0170 | [Security Policy](tasks/security_policy.md) | Write and maintain a security policy that covers the SAS Viya deployment | Organization & Governance | - |
+| 0180 | [Authorization Model](tasks/authorization_model.md) | Write and maintain a security model or an authorization model | Organization & Governance | Yes |
+| 0190 | [Select Log & Metric Monitoring and Alerting Solution](tasks/select_monitoring_solution.md) | Choose a log and metric monitoring and alerting solution | Observability | - |
+| 0200 | [Set Up Monitoring and Alerting](tasks/observability_monitoring_and_alerting.md) | Learn how to deploy, update and use either SAS Viya Monitoring for Kubernetes or a cloud provider's observability tools to leverage logging, monitoring and alerting capabilties in your Viya platform. | Observability | Yes |
+| 0210 | [Understand how to Check the Status of Services](tasks/how_to_check_service_status.md) | Ensure you know how to check the status of all SAS Viya services ad hoc at any time | Observability | - |
+| 0220 | [Configure audit record archival](tasks/audit_record_archival.md) | Configure and schedule the archiving of SAS Viya audit records. | Observability | - |
+| 0230 | [Enable job to purge archived audit records](tasks/purge_archived_audit_records.md) | Enable the routine purging of archived audit records from the archive location (PV) | Observability | - |
+| 0240 | [Validate your SAS Viya Deployment](tasks/validate_deployment.md) | Define a set of tests to validate that your SAS Viya deployment is functioning correctly | SAS Administration | Yes |
+| 0250 | [Define a backup and restore strategy](tasks/backup_and_restore.md) | Define a backup and restore strategy | SAS Administration | Yes |
+| 0260 | [Know how to Contact SAS Technical Support for Help](tasks/contact_SAS_technical_support.md) | Ensure all SAS platform administration staff know how to contact SAS Technical Support for help | SAS Administration | - |
+| 0270 | [Identify Components of SAS and Third-Party Software](tasks/identify_viya_components.md) | Ensure you can identify the components of SAS and third-party software that make up SAS Viya | SAS Administration | - |
+| 0280 | [Decide approach to applying updates](tasks/decide_update_approach.md) | Decide how and when your SAS Viya software will be updated | SAS Administration | - |
+| 0290 | [Configure SAS Studio Preferences](tasks/configure_sas_studio_preferences.md) | Configure SAS Studio Preferences | SAS Administration | - |
+| 0300 | [Define a Process for Onboarding and Offboarding Users](tasks/process_for_onboarding_and_offboarding_users.md) | Document any steps that must be performed when new users are onboarded and offboarded | SAS Administration | Yes |
+| 0310 | [Secure the sasboot password](tasks/secure_sasboot_password.md) | Disable the sasboot password reset feature after you have finished setting up identities and initial administrators | SAS Administration | - |
+| 0320 | [Secure Default Caslibs, especially the Public Caslib](tasks/secure_default_caslibs.md) | Review and change default access controls on default CAS libraries | CAS | - |
+| 0330 | [Consider relocating CAS_DISK_CACHE](tasks/relocate_cas_disk_cache.md) | Relocate the CAS_DISK_CACHE for CAS servers | CAS | - |
+| 0340 | [Configure CAS Allowlist](tasks/configure_cas_allowlist.md) | Configure CAS allowlist for user-defined CAS libraries | CAS | Yes |
+| 0350 | [Configure External Access to CAS](tasks/configure_cas_external_access.md) | Configure access to CAS from outside your SAS Viya deployment | CAS | - |
+| 0360 | [Set location for SAS Work and other Programming Run-Time Temporary Files](tasks/move_sas_work_and_spre_temporary_files_location.md) | Move SAS Work and other Programming Run-Time Temporary Files to a better location than the default | SAS Programming Run-time | - |
+| 0370 | [Configure Common Programming Run-Time Autoexec Statements](tasks/common_programming_run-time_options.md) | Configure statements in SAS Programming Run-Time Autoexec code blocks, to set commonly used SAS options for macro programming, performance tuning, use of mail servers and pre-assigning SAS libraries. | SAS Programming Run-time | Yes |
+| 0380 | [Modify Launcher and SAS Programming Run-Time Server Contexts](tasks/modify_programming_launcher_server_contexts.md) | Modify Launcher and Server contexts for SAS Compute Server, SAS Connect Server and SAS Batch Server | SAS Programming Run-time | - |
+| 0390 | [Define Library Connection Data Sources as a Resource in SAS Programming Run-Time Contexts](tasks/manage_connections_to_data_sources.md) | Compute, Connect and Batch contexts can be associated with Required Resources, the first of which is a Library Connection. | SAS Programming Run-time | - |
+| 0400 | [Configure lockdown for SAS Programming run-time servers](tasks/configure_lockdown.md) | Configure lockdown for SAS Programming Run-Time servers | SAS Programming Run-time | - |
+| 0410 | [Configure Programming Allowlist](tasks/configure_programming_allowlist.md) | Configure SAS Programming Run-Time for user-defined paths | SAS Programming Run-time | - |
+| 0420 | [Configure umask for SAS Programmning run-time servers](tasks/configure_programming_run-time_umask.md) | Configure umask to e.g. 0002 for SAS Programming Run-Time servers, so that files created by users (including datasets in path-based libraries) are read-write for members of the user's primary POSIX group | SAS Programming Run-time | - |
+| 0430 | [Set User Process Limit](tasks/set_user_process_limit.md) | Set the maximum number of launched compute, connect or batch programming run-time pods each user may run simultaneously | SAS Programming Run-time | - |
+| 0440 | [Tune the Programming Run-Time](tasks/tune_programming_run-time.md) | Tune the SAS Viya Platform Programming Run-time for better performance with your workload | SAS Programming Run-time | - |
+| 0450 | [Design and Maintain a Schedule of SAS Administration Housekeeping Activities](tasks/maintain_housekeeping_schedule.md) | Design and maintain a schedule of SAS Viya platform administration housekeeping activities, specifying when regular tasks should be performed. | SAS Administration | Yes |
 
 ## Regular Task Checklist
 
@@ -81,29 +81,29 @@ This table lists smaller tasks that should be repeated on a regular basis. See t
 
 | # ▴ | Title | Description | Frequency | Topic | Essential |
 |---|---|---|---|---|---|
-| 0460 | [Renew your SAS Viya License](tasks\update_licenses.md) | Obtain and apply a new SAS Viya platform license before your existing license expires | Annually | Kubernetes & IT Admin | - |
-| 0470 | [Update the SAS Viya CLI](tasks\update_sas_viya_cli.md) | Ensure you have installed the sas-viya cli and its plugins | Quarterly | Kubernetes & IT Admin | - |
-| 0480 | [Renew your OIDC client secret](tasks\renew_oidc_client_secret.md) | If your SAS Viya deployment is configured to use OIDC, renew your OIDC client secret before it expires. | When secret changes | Kubernetes & IT Admin | - |
-| 0490 | [Update External Credentials](tasks\update_external_credentials.md) | When external credentials change, follow your defined process to update them in SAS Viya | When credentials change | Kubernetes & IT Admin | - |
-| 0500 | [Check the Status of SAS services](tasks\check_service_status.md) | Regularly check the status of SAS services | Daily | Observability | - |
-| 0510 | [Monitor Memory, CPU, Network, and Disk Throughput Usage](tasks\monitor_usage.md) | Monitor memory usage, CPU usage, network I/O usage, disk throughput usage, input/output operations per second (IOPS), etc | Daily | Observability | - |
-| 0520 | [Monitor Log Messages](tasks\monitor_logs.md) | Monitor log messages | Daily | Observability | - |
-| 0530 | [Examine the User Activity Report](tasks\examine_user_activity_report.md) | Examine the user activity report | Weekly | Observability | - |
-| 0540 | [Change log levels](tasks\change_log_levels.md) | Change the log threshold for a SAS component or service, to increase or decrease the detail of log messages it produces | When troubleshooting | Observability | - |
-| 0550 | [Monitor Storage Space](tasks\monitor_storage_space.md) | Monitor the disk space used for SAS Viya | Weekly | Observability | - |
-| 0560 | [Monitor Observability Storage](tasks\monitor_observabilty_storage.md) | Monitor the disk or other storage space used for the log and metric monitoring tools, and other observability tools deployed to monitor SAS Viya | Weekly | Observability | - |
-| 0570 | [Stop and Start SAS Viya's Monitoring and Logging components](tasks\stop_and_start_sas_viya_monitoring_for_kubernetes.md) | Ensure you can stop the logging and monitoring solution and that you can start it back up when needed again. | When not in use | Observability | - |
-| 0580 | [Onboard and Offboard Users](tasks\onboard_and_offboard_users.md) | Onboard new users and offboard old users | Weekly | SAS Administration | - |
-| 0590 | [Keep your Software Current](tasks\keep_software_current.md) | Keep your software current with patch and version updates to stay within Standard Support guidelines. | Monthly | SAS Administration | - |
-| 0600 | [Regularly Re-Validate your SAS Viya Deployment](tasks\validate_deployment_regularly.md) | Run a set of tests to validate that your SAS Viya deployment is functioning correctly | Weekly | SAS Administration | - |
-| 0610 | [Periodically Run an Inventory Scan on the Viya Environment](tasks\inventory_scan.md) | Periodically Run an Inventory Scan on the Viya Environment | Monthly | SAS Administration | - |
-| 0620 | [Stop and Start SAS Viya software](tasks\stop_and_start_viya.md) | Ensure you can scale your SAS Viya deployment to zero, and that you can scale it back up when needed again. | When not in use | SAS Administration | Yes |
-| 0630 | [Inspect the Status of Scheduled Jobs](tasks\inspect_job_status.md) | Inspect the status of scheduled jobs | Daily | SAS Administration | - |
-| 0640 | [Test the Process to Restore From Backups](tasks\test_restore_process.md) | Periodically test the process to restore from backups | Monthly | SAS Administration | - |
-| 0650 | [Configure CAS server startup to load data](tasks\cas_server_startup.md) | Configure CAS server startup to load data | Monthly | CAS | - |
-| 0660 | [Monitor Compute Sessions](tasks\monitor_compute_sessions.md) | Use the sas-viya CLI, log and metric monitoring tools to monitor compute sessions | Daily or as often as necessary | SAS Programming Run-time | - |
-| 0670 | [Manage content stored in PostgreSQL](tasks\manage_postgresql_content.md) | Manage content stored in PostgresQL | Monthly | PostgreSQL | - |
-| 0680 | [Maintain SAS Infrastructure Data Server](tasks\maintain_postgresql_server.md) | Perform routine maintenance on the SAS Infrastructure Data Server | Monthly | PostgreSQL | - |
+| 0460 | [Renew your SAS Viya License](tasks/update_licenses.md) | Obtain and apply a new SAS Viya platform license before your existing license expires | Annually | Kubernetes & IT Admin | - |
+| 0470 | [Update the SAS Viya CLI](tasks/update_sas_viya_cli.md) | Ensure you have installed the sas-viya cli and its plugins | Quarterly | Kubernetes & IT Admin | - |
+| 0480 | [Renew your OIDC client secret](tasks/renew_oidc_client_secret.md) | If your SAS Viya deployment is configured to use OIDC, renew your OIDC client secret before it expires. | When secret changes | Kubernetes & IT Admin | - |
+| 0490 | [Update External Credentials](tasks/update_external_credentials.md) | When external credentials change, follow your defined process to update them in SAS Viya | When credentials change | Kubernetes & IT Admin | - |
+| 0500 | [Check the Status of SAS services](tasks/check_service_status.md) | Regularly check the status of SAS services | Daily | Observability | - |
+| 0510 | [Monitor Memory, CPU, Network, and Disk Throughput Usage](tasks/monitor_usage.md) | Monitor memory usage, CPU usage, network I/O usage, disk throughput usage, input/output operations per second (IOPS), etc | Daily | Observability | - |
+| 0520 | [Monitor Log Messages](tasks/monitor_logs.md) | Monitor log messages | Daily | Observability | - |
+| 0530 | [Examine the User Activity Report](tasks/examine_user_activity_report.md) | Examine the user activity report | Weekly | Observability | - |
+| 0540 | [Change log levels](tasks/change_log_levels.md) | Change the log threshold for a SAS component or service, to increase or decrease the detail of log messages it produces | When troubleshooting | Observability | - |
+| 0550 | [Monitor Storage Space](tasks/monitor_storage_space.md) | Monitor the disk space used for SAS Viya | Weekly | Observability | - |
+| 0560 | [Monitor Observability Storage](tasks/monitor_observabilty_storage.md) | Monitor the disk or other storage space used for the log and metric monitoring tools, and other observability tools deployed to monitor SAS Viya | Weekly | Observability | - |
+| 0570 | [Stop and Start SAS Viya's Monitoring and Logging components](tasks/stop_and_start_sas_viya_monitoring_for_kubernetes.md) | Ensure you can stop the logging and monitoring solution and that you can start it back up when needed again. | When not in use | Observability | - |
+| 0580 | [Onboard and Offboard Users](tasks/onboard_and_offboard_users.md) | Onboard new users and offboard old users | Weekly | SAS Administration | - |
+| 0590 | [Keep your Software Current](tasks/keep_software_current.md) | Keep your software current with patch and version updates to stay within Standard Support guidelines. | Monthly | SAS Administration | - |
+| 0600 | [Regularly Re-Validate your SAS Viya Deployment](tasks/validate_deployment_regularly.md) | Run a set of tests to validate that your SAS Viya deployment is functioning correctly | Weekly | SAS Administration | - |
+| 0610 | [Periodically Run an Inventory Scan on the Viya Environment](tasks/inventory_scan.md) | Periodically Run an Inventory Scan on the Viya Environment | Monthly | SAS Administration | - |
+| 0620 | [Stop and Start SAS Viya software](tasks/stop_and_start_viya.md) | Ensure you can scale your SAS Viya deployment to zero, and that you can scale it back up when needed again. | When not in use | SAS Administration | Yes |
+| 0630 | [Inspect the Status of Scheduled Jobs](tasks/inspect_job_status.md) | Inspect the status of scheduled jobs | Daily | SAS Administration | - |
+| 0640 | [Test the Process to Restore From Backups](tasks/test_restore_process.md) | Periodically test the process to restore from backups | Monthly | SAS Administration | - |
+| 0650 | [Configure CAS server startup to load data](tasks/cas_server_startup.md) | Configure CAS server startup to load data | Monthly | CAS | - |
+| 0660 | [Monitor Compute Sessions](tasks/monitor_compute_sessions.md) | Use the sas-viya CLI, log and metric monitoring tools to monitor compute sessions | Daily or as often as necessary | SAS Programming Run-time | - |
+| 0670 | [Manage content stored in PostgreSQL](tasks/manage_postgresql_content.md) | Manage content stored in PostgresQL | Monthly | PostgreSQL | - |
+| 0680 | [Maintain SAS Infrastructure Data Server](tasks/maintain_postgresql_server.md) | Perform routine maintenance on the SAS Infrastructure Data Server | Monthly | PostgreSQL | - |
 
 ## Regular Task Schedule
 
@@ -113,28 +113,28 @@ This table shows the same regular tasks as the [Regular Task Checklist](#regular
 
 | # ▴ | Title | Annually | Quarterly | Monthly | Weekly | Daily | Other |
 |---|---|:-:|:-:|:-:|:-:|:-:|---|
-| 0460 | [Renew your SAS Viya License](tasks\update_licenses.md) | ◎ |  |  |  |  |  |
-| 0470 | [Update the SAS Viya CLI](tasks\update_sas_viya_cli.md) |  | ◎ |  |  |  |  |
-| 0480 | [Renew your OIDC client secret](tasks\renew_oidc_client_secret.md) |  |  |  |  |  | When secret changes |
-| 0490 | [Update External Credentials](tasks\update_external_credentials.md) |  |  |  |  |  | When credentials change |
-| 0500 | [Check the Status of SAS services](tasks\check_service_status.md) |  |  |  |  | ◎ |  |
-| 0510 | [Monitor Memory, CPU, Network, and Disk Throughput Usage](tasks\monitor_usage.md) |  |  |  |  | ◎ |  |
-| 0520 | [Monitor Log Messages](tasks\monitor_logs.md) |  |  |  |  | ◎ |  |
-| 0530 | [Examine the User Activity Report](tasks\examine_user_activity_report.md) |  |  |  | ◎ |  |  |
-| 0540 | [Change log levels](tasks\change_log_levels.md) |  |  |  |  |  | When troubleshooting |
-| 0550 | [Monitor Storage Space](tasks\monitor_storage_space.md) |  |  |  | ◎ |  |  |
-| 0560 | [Monitor Observability Storage](tasks\monitor_observabilty_storage.md) |  |  |  | ◎ |  |  |
-| 0570 | [Stop and Start SAS Viya's Monitoring and Logging components](tasks\stop_and_start_sas_viya_monitoring_for_kubernetes.md) |  |  |  |  |  | When not in use |
-| 0580 | [Onboard and Offboard Users](tasks\onboard_and_offboard_users.md) |  |  |  | ◎ |  |  |
-| 0590 | [Keep your Software Current](tasks\keep_software_current.md) |  |  | ◎ |  |  |  |
-| 0600 | [Regularly Re-Validate your SAS Viya Deployment](tasks\validate_deployment_regularly.md) |  |  |  | ◎ |  |  |
-| 0610 | [Periodically Run an Inventory Scan on the Viya Environment](tasks\inventory_scan.md) |  |  | ◎ |  |  |  |
-| 0620 | [Stop and Start SAS Viya software](tasks\stop_and_start_viya.md) |  |  |  |  |  | When not in use |
-| 0630 | [Inspect the Status of Scheduled Jobs](tasks\inspect_job_status.md) |  |  |  |  | ◎ |  |
-| 0640 | [Test the Process to Restore From Backups](tasks\test_restore_process.md) |  |  | ◎ |  |  |  |
-| 0650 | [Configure CAS server startup to load data](tasks\cas_server_startup.md) |  |  | ◎ |  |  |  |
-| 0660 | [Monitor Compute Sessions](tasks\monitor_compute_sessions.md) |  |  |  |  |  | Daily or as often as necessary |
-| 0670 | [Manage content stored in PostgreSQL](tasks\manage_postgresql_content.md) |  |  | ◎ |  |  |  |
-| 0680 | [Maintain SAS Infrastructure Data Server](tasks\maintain_postgresql_server.md) |  |  | ◎ |  |  |  |
+| 0460 | [Renew your SAS Viya License](tasks/update_licenses.md) | ◎ |  |  |  |  |  |
+| 0470 | [Update the SAS Viya CLI](tasks/update_sas_viya_cli.md) |  | ◎ |  |  |  |  |
+| 0480 | [Renew your OIDC client secret](tasks/renew_oidc_client_secret.md) |  |  |  |  |  | When secret changes |
+| 0490 | [Update External Credentials](tasks/update_external_credentials.md) |  |  |  |  |  | When credentials change |
+| 0500 | [Check the Status of SAS services](tasks/check_service_status.md) |  |  |  |  | ◎ |  |
+| 0510 | [Monitor Memory, CPU, Network, and Disk Throughput Usage](tasks/monitor_usage.md) |  |  |  |  | ◎ |  |
+| 0520 | [Monitor Log Messages](tasks/monitor_logs.md) |  |  |  |  | ◎ |  |
+| 0530 | [Examine the User Activity Report](tasks/examine_user_activity_report.md) |  |  |  | ◎ |  |  |
+| 0540 | [Change log levels](tasks/change_log_levels.md) |  |  |  |  |  | When troubleshooting |
+| 0550 | [Monitor Storage Space](tasks/monitor_storage_space.md) |  |  |  | ◎ |  |  |
+| 0560 | [Monitor Observability Storage](tasks/monitor_observabilty_storage.md) |  |  |  | ◎ |  |  |
+| 0570 | [Stop and Start SAS Viya's Monitoring and Logging components](tasks/stop_and_start_sas_viya_monitoring_for_kubernetes.md) |  |  |  |  |  | When not in use |
+| 0580 | [Onboard and Offboard Users](tasks/onboard_and_offboard_users.md) |  |  |  | ◎ |  |  |
+| 0590 | [Keep your Software Current](tasks/keep_software_current.md) |  |  | ◎ |  |  |  |
+| 0600 | [Regularly Re-Validate your SAS Viya Deployment](tasks/validate_deployment_regularly.md) |  |  |  | ◎ |  |  |
+| 0610 | [Periodically Run an Inventory Scan on the Viya Environment](tasks/inventory_scan.md) |  |  | ◎ |  |  |  |
+| 0620 | [Stop and Start SAS Viya software](tasks/stop_and_start_viya.md) |  |  |  |  |  | When not in use |
+| 0630 | [Inspect the Status of Scheduled Jobs](tasks/inspect_job_status.md) |  |  |  |  | ◎ |  |
+| 0640 | [Test the Process to Restore From Backups](tasks/test_restore_process.md) |  |  | ◎ |  |  |  |
+| 0650 | [Configure CAS server startup to load data](tasks/cas_server_startup.md) |  |  | ◎ |  |  |  |
+| 0660 | [Monitor Compute Sessions](tasks/monitor_compute_sessions.md) |  |  |  |  |  | Daily or as often as necessary |
+| 0670 | [Manage content stored in PostgreSQL](tasks/manage_postgresql_content.md) |  |  | ◎ |  |  |  |
+| 0680 | [Maintain SAS Infrastructure Data Server](tasks/maintain_postgresql_server.md) |  |  | ◎ |  |  |  |
 
-</br>Generated by build_from_template.py on: 21 Jul 2025 17:28:38.</br>
+</br>Generated by build_from_template.py on: 23 Sep 2025 16:57:25.</br>

--- a/scripts/checklistsharedfunctions.py
+++ b/scripts/checklistsharedfunctions.py
@@ -11,6 +11,7 @@
 # 03FEB2022 Creation
 # 20MAR2023 Added support for optional Frequency, Topic and Essential columns
 # 20DEC2024 Added rtfreq function to create regular task frequency table
+# 23SEP2025 Force markdown links to be built with a specific separator string, "/"
 #
 # Copyright © 2022-2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
@@ -18,6 +19,7 @@
 from os import listdir
 from os.path import isfile, join
 strBlockCharacter="◎"
+strUrlSeparator="/"
 
 def toc(fileOut,strProjectRootPath,strTaskSubdirectory,strTagFilter,intSortColumn,boolReverse,boolShowTags,boolShowFreq,boolShowTopic,boolShowEssential,strTopicFilter):
 
@@ -110,7 +112,8 @@ def toc(fileOut,strProjectRootPath,strTaskSubdirectory,strTagFilter,intSortColum
                     # No topic filter
             if boolInclude:
                 # fileOut.write('Title: '+strTaskTitle+', Description: '+strTaskDescription+', Tags: '+strTaskTags+', Frequency: '+strTaskFreq+', Topic: '+strTopic+', Essential: '+strEssential+'</br>\n')
-                strTaskFileRelativePath = join(strTaskSubdirectory, strTaskFile)
+                # strTaskFileRelativePath = join(strTaskSubdirectory, strTaskFile) # Joined with '\', but needs to join with '/'
+                strTaskFileRelativePath = strTaskSubdirectory + strUrlSeparator + strTaskFile
                 # Ensure this comment matches similar comment below!
                 # lstTOCLine[0] = SortString
                 # lstTOCLine[1] = Title
@@ -298,7 +301,8 @@ def rtfreq(fileOut,strProjectRootPath,strTaskSubdirectory,strTagFilter,intSortCo
                     # No topic filter
             if boolInclude:
                 # fileOut.write('Title: '+strTaskTitle+', Description: '+strTaskDescription+', Tags: '+strTaskTags+', Frequency: '+strTaskFreq+', Topic: '+strTopic+', Essential: '+strEssential+'</br>\n')
-                strTaskFileRelativePath = join(strTaskSubdirectory, strTaskFile)
+                # strTaskFileRelativePath = join(strTaskSubdirectory, strTaskFile) # Joined with '\', but needs to join with '/'
+                strTaskFileRelativePath = strTaskSubdirectory + strUrlSeparator + strTaskFile
                 # Ensure this comment matches similar comment below!
                 # lstRTFREQLine[0] = SortString
                 # lstRTFREQLine[1] = Title

--- a/scripts/checklistsharedfunctions.py
+++ b/scripts/checklistsharedfunctions.py
@@ -11,7 +11,7 @@
 # 03FEB2022 Creation
 # 20MAR2023 Added support for optional Frequency, Topic and Essential columns
 # 20DEC2024 Added rtfreq function to create regular task frequency table
-# 23SEP2025 Force markdown links to be built with a specific separator string, "/"
+# 23SEP2025 Force markdown links to be built with a specific separator string, "/".
 #
 # Copyright © 2022-2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/status.md
+++ b/status.md
@@ -52,74 +52,74 @@ These tasks are done, finished, complete and ready for public consumption.
 
 | # ▴ | Title | Description |
 |---|---|---|
-| 0010 | [Automate your SAS Viya Deployment Process](tasks\automate_environment_creation.md) | Automate the process of creating and configuring your SAS Viya deployment |
-| 0020 | [Install the SAS Viya CLI](tasks\install_sas_viya_cli.md) | Ensure you have installed the sas-viya cli and its plugins. |
-| 0030 | [Develop an update plan](tasks\develop_update_plan.md) | Develop an update plan: outline tasks required before, during and after an update |
-| 0040 | [Maintain a Secure Password Database](tasks\maintain_password_database.md) | Maintain a secure and encrypted password-protected password database using an appropriate software tool or service |
-| 0050 | [Update TLS certificates](tasks\encryption_with_public_ca_signed_tls_certificates.md) | Generate new or renew expiring TLS certificates used for encryption of data in transit. |
-| 0060 | [Load POSIX attributes](tasks\load_posix_attributes.md) | Load POSIX attributes for identities when attributes are not returned from the authentication provider |
-| 0070 | [Create and Configure User home-directories](tasks\createandconfigure_user_homedirs.md) | Create and configure user-home directories |
-| 0080 | [Ensure You Have Provided Sufficient Storage for Path-Based Caslibs](tasks\ensure_storage_for_caslibs.md) | Ensure you have provided sufficient filesystem storage of an appropriate type for path-based caslibs. |
-| 0090 | [Define a Process for Updating External Credentials](tasks\process_for_updating_external_credentials.md) | Define a when and how you will update credentials that are stored in SAS Viya for external systems such as databases, when they change |
-| 0100 | [Know when to renew your OIDC client secret](tasks\when_to_renew_oidc_client_secret.md) | Open ID Connect uses expiring client secrets with a maximum lifetime of 2 years. If your SAS Viya deployment is configured to use OIDC, ensure that you know when this client secret expires so that you can renew it before it does. |
-| 0110 | [Configure Open Source Integration](tasks\configure_open_source_integration.md) | Configure open source integration |
-| 0120 | [Review Tuning Recommendations](tasks\tuning_recommendations.md) | Review SAS Viya platform tuning recommendations and apply as needed |
-| 0130 | [Configure CORS and CSRF settings](tasks\configure_cors_and_csrf.md) | Configure the SAS Viya platform's Cross-Origin Resource Sharing (CORS) and Cross-Site Request Forgery (CSRF) settings for deployments behind a DNS alias or proxy, and for SAS Visual Analytics |
-| 0140 | [Service Level Agreement](tasks\sla.md) | For enterprise-scale deployments, define a Service Level Agreement (SLA) |
-| 0150 | [Define your organizationâ€™s SAS support team structure, roles, and responsibilities](tasks\define_org_support_structure.md) | Define your organizationâ€™s SAS support team structure, roles, and responsibilities |
-| 0160 | [Premium Support](tasks\premium_support.md) | Consider whether you require premium or customized support for your SAS deployment |
-| 0170 | [Security Policy](tasks\security_policy.md) | Write and maintain a security policy that covers the SAS Viya deployment |
-| 0180 | [Authorization Model](tasks\authorization_model.md) | Write and maintain a security model or an authorization model |
-| 0190 | [Select Log & Metric Monitoring and Alerting Solution](tasks\select_monitoring_solution.md) | Choose a log and metric monitoring and alerting solution |
-| 0200 | [Set Up Monitoring and Alerting](tasks\observability_monitoring_and_alerting.md) | Learn how to deploy, update and use either SAS Viya Monitoring for Kubernetes or a cloud provider's observability tools to leverage logging, monitoring and alerting capabilties in your Viya platform. |
-| 0210 | [Understand how to Check the Status of Services](tasks\how_to_check_service_status.md) | Ensure you know how to check the status of all SAS Viya services ad hoc at any time |
-| 0220 | [Configure audit record archival](tasks\audit_record_archival.md) | Configure and schedule the archiving of SAS Viya audit records. |
-| 0230 | [Enable job to purge archived audit records](tasks\purge_archived_audit_records.md) | Enable the routine purging of archived audit records from the archive location (PV) |
-| 0240 | [Validate your SAS Viya Deployment](tasks\validate_deployment.md) | Define a set of tests to validate that your SAS Viya deployment is functioning correctly |
-| 0250 | [Define a backup and restore strategy](tasks\backup_and_restore.md) | Define a backup and restore strategy |
-| 0260 | [Know how to Contact SAS Technical Support for Help](tasks\contact_SAS_technical_support.md) | Ensure all SAS platform administration staff know how to contact SAS Technical Support for help |
-| 0270 | [Identify Components of SAS and Third-Party Software](tasks\identify_viya_components.md) | Ensure you can identify the components of SAS and third-party software that make up SAS Viya |
-| 0280 | [Decide approach to applying updates](tasks\decide_update_approach.md) | Decide how and when your SAS Viya software will be updated |
-| 0290 | [Configure SAS Studio Preferences](tasks\configure_sas_studio_preferences.md) | Configure SAS Studio Preferences |
-| 0300 | [Define a Process for Onboarding and Offboarding Users](tasks\process_for_onboarding_and_offboarding_users.md) | Document any steps that must be performed when new users are onboarded and offboarded |
-| 0310 | [Secure the sasboot password](tasks\secure_sasboot_password.md) | Disable the sasboot password reset feature after you have finished setting up identities and initial administrators |
-| 0320 | [Secure Default Caslibs, especially the Public Caslib](tasks\secure_default_caslibs.md) | Review and change default access controls on default CAS libraries |
-| 0330 | [Consider relocating CAS_DISK_CACHE](tasks\relocate_cas_disk_cache.md) | Relocate the CAS_DISK_CACHE for CAS servers |
-| 0340 | [Configure CAS Allowlist](tasks\configure_cas_allowlist.md) | Configure CAS allowlist for user-defined CAS libraries |
-| 0350 | [Configure External Access to CAS](tasks\configure_cas_external_access.md) | Configure access to CAS from outside your SAS Viya deployment |
-| 0360 | [Set location for SAS Work and other Programming Run-Time Temporary Files](tasks\move_sas_work_and_spre_temporary_files_location.md) | Move SAS Work and other Programming Run-Time Temporary Files to a better location than the default |
-| 0370 | [Configure Common Programming Run-Time Autoexec Statements](tasks\common_programming_run-time_options.md) | Configure statements in SAS Programming Run-Time Autoexec code blocks, to set commonly used SAS options for macro programming, performance tuning, use of mail servers and pre-assigning SAS libraries. |
-| 0380 | [Modify Launcher and SAS Programming Run-Time Server Contexts](tasks\modify_programming_launcher_server_contexts.md) | Modify Launcher and Server contexts for SAS Compute Server, SAS Connect Server and SAS Batch Server |
-| 0390 | [Define Library Connection Data Sources as a Resource in SAS Programming Run-Time Contexts](tasks\manage_connections_to_data_sources.md) | Compute, Connect and Batch contexts can be associated with Required Resources, the first of which is a Library Connection. |
-| 0400 | [Configure lockdown for SAS Programming run-time servers](tasks\configure_lockdown.md) | Configure lockdown for SAS Programming Run-Time servers |
-| 0410 | [Configure Programming Allowlist](tasks\configure_programming_allowlist.md) | Configure SAS Programming Run-Time for user-defined paths |
-| 0420 | [Configure umask for SAS Programmning run-time servers](tasks\configure_programming_run-time_umask.md) | Configure umask to e.g. 0002 for SAS Programming Run-Time servers, so that files created by users (including datasets in path-based libraries) are read-write for members of the user's primary POSIX group |
-| 0430 | [Set User Process Limit](tasks\set_user_process_limit.md) | Set the maximum number of launched compute, connect or batch programming run-time pods each user may run simultaneously |
-| 0440 | [Tune the Programming Run-Time](tasks\tune_programming_run-time.md) | Tune the SAS Viya Platform Programming Run-time for better performance with your workload |
-| 0450 | [Design and Maintain a Schedule of SAS Administration Housekeeping Activities](tasks\maintain_housekeeping_schedule.md) | Design and maintain a schedule of SAS Viya platform administration housekeeping activities, specifying when regular tasks should be performed. |
-| 0460 | [Renew your SAS Viya License](tasks\update_licenses.md) | Obtain and apply a new SAS Viya platform license before your existing license expires |
-| 0470 | [Update the SAS Viya CLI](tasks\update_sas_viya_cli.md) | Ensure you have installed the sas-viya cli and its plugins |
-| 0480 | [Renew your OIDC client secret](tasks\renew_oidc_client_secret.md) | If your SAS Viya deployment is configured to use OIDC, renew your OIDC client secret before it expires. |
-| 0490 | [Update External Credentials](tasks\update_external_credentials.md) | When external credentials change, follow your defined process to update them in SAS Viya |
-| 0500 | [Check the Status of SAS services](tasks\check_service_status.md) | Regularly check the status of SAS services |
-| 0510 | [Monitor Memory, CPU, Network, and Disk Throughput Usage](tasks\monitor_usage.md) | Monitor memory usage, CPU usage, network I/O usage, disk throughput usage, input/output operations per second (IOPS), etc |
-| 0520 | [Monitor Log Messages](tasks\monitor_logs.md) | Monitor log messages |
-| 0530 | [Examine the User Activity Report](tasks\examine_user_activity_report.md) | Examine the user activity report |
-| 0540 | [Change log levels](tasks\change_log_levels.md) | Change the log threshold for a SAS component or service, to increase or decrease the detail of log messages it produces |
-| 0550 | [Monitor Storage Space](tasks\monitor_storage_space.md) | Monitor the disk space used for SAS Viya |
-| 0560 | [Monitor Observability Storage](tasks\monitor_observabilty_storage.md) | Monitor the disk or other storage space used for the log and metric monitoring tools, and other observability tools deployed to monitor SAS Viya |
-| 0570 | [Stop and Start SAS Viya's Monitoring and Logging components](tasks\stop_and_start_sas_viya_monitoring_for_kubernetes.md) | Ensure you can stop the logging and monitoring solution and that you can start it back up when needed again. |
-| 0580 | [Onboard and Offboard Users](tasks\onboard_and_offboard_users.md) | Onboard new users and offboard old users |
-| 0590 | [Keep your Software Current](tasks\keep_software_current.md) | Keep your software current with patch and version updates to stay within Standard Support guidelines. |
-| 0600 | [Regularly Re-Validate your SAS Viya Deployment](tasks\validate_deployment_regularly.md) | Run a set of tests to validate that your SAS Viya deployment is functioning correctly |
-| 0610 | [Periodically Run an Inventory Scan on the Viya Environment](tasks\inventory_scan.md) | Periodically Run an Inventory Scan on the Viya Environment |
-| 0620 | [Stop and Start SAS Viya software](tasks\stop_and_start_viya.md) | Ensure you can scale your SAS Viya deployment to zero, and that you can scale it back up when needed again. |
-| 0630 | [Inspect the Status of Scheduled Jobs](tasks\inspect_job_status.md) | Inspect the status of scheduled jobs |
-| 0640 | [Test the Process to Restore From Backups](tasks\test_restore_process.md) | Periodically test the process to restore from backups |
-| 0650 | [Configure CAS server startup to load data](tasks\cas_server_startup.md) | Configure CAS server startup to load data |
-| 0660 | [Monitor Compute Sessions](tasks\monitor_compute_sessions.md) | Use the sas-viya CLI, log and metric monitoring tools to monitor compute sessions |
-| 0670 | [Manage content stored in PostgreSQL](tasks\manage_postgresql_content.md) | Manage content stored in PostgresQL |
-| 0680 | [Maintain SAS Infrastructure Data Server](tasks\maintain_postgresql_server.md) | Perform routine maintenance on the SAS Infrastructure Data Server |
+| 0010 | [Automate your SAS Viya Deployment Process](tasks/automate_environment_creation.md) | Automate the process of creating and configuring your SAS Viya deployment |
+| 0020 | [Install the SAS Viya CLI](tasks/install_sas_viya_cli.md) | Ensure you have installed the sas-viya cli and its plugins. |
+| 0030 | [Develop an update plan](tasks/develop_update_plan.md) | Develop an update plan: outline tasks required before, during and after an update |
+| 0040 | [Maintain a Secure Password Database](tasks/maintain_password_database.md) | Maintain a secure and encrypted password-protected password database using an appropriate software tool or service |
+| 0050 | [Update TLS certificates](tasks/encryption_with_public_ca_signed_tls_certificates.md) | Generate new or renew expiring TLS certificates used for encryption of data in transit. |
+| 0060 | [Load POSIX attributes](tasks/load_posix_attributes.md) | Load POSIX attributes for identities when attributes are not returned from the authentication provider |
+| 0070 | [Create and Configure User home-directories](tasks/createandconfigure_user_homedirs.md) | Create and configure user-home directories |
+| 0080 | [Ensure You Have Provided Sufficient Storage for Path-Based Caslibs](tasks/ensure_storage_for_caslibs.md) | Ensure you have provided sufficient filesystem storage of an appropriate type for path-based caslibs. |
+| 0090 | [Define a Process for Updating External Credentials](tasks/process_for_updating_external_credentials.md) | Define a when and how you will update credentials that are stored in SAS Viya for external systems such as databases, when they change |
+| 0100 | [Know when to renew your OIDC client secret](tasks/when_to_renew_oidc_client_secret.md) | Open ID Connect uses expiring client secrets with a maximum lifetime of 2 years. If your SAS Viya deployment is configured to use OIDC, ensure that you know when this client secret expires so that you can renew it before it does. |
+| 0110 | [Configure Open Source Integration](tasks/configure_open_source_integration.md) | Configure open source integration |
+| 0120 | [Review Tuning Recommendations](tasks/tuning_recommendations.md) | Review SAS Viya platform tuning recommendations and apply as needed |
+| 0130 | [Configure CORS and CSRF settings](tasks/configure_cors_and_csrf.md) | Configure the SAS Viya platform's Cross-Origin Resource Sharing (CORS) and Cross-Site Request Forgery (CSRF) settings for deployments behind a DNS alias or proxy, and for SAS Visual Analytics |
+| 0140 | [Service Level Agreement](tasks/sla.md) | For enterprise-scale deployments, define a Service Level Agreement (SLA) |
+| 0150 | [Define your organizationâ€™s SAS support team structure, roles, and responsibilities](tasks/define_org_support_structure.md) | Define your organizationâ€™s SAS support team structure, roles, and responsibilities |
+| 0160 | [Premium Support](tasks/premium_support.md) | Consider whether you require premium or customized support for your SAS deployment |
+| 0170 | [Security Policy](tasks/security_policy.md) | Write and maintain a security policy that covers the SAS Viya deployment |
+| 0180 | [Authorization Model](tasks/authorization_model.md) | Write and maintain a security model or an authorization model |
+| 0190 | [Select Log & Metric Monitoring and Alerting Solution](tasks/select_monitoring_solution.md) | Choose a log and metric monitoring and alerting solution |
+| 0200 | [Set Up Monitoring and Alerting](tasks/observability_monitoring_and_alerting.md) | Learn how to deploy, update and use either SAS Viya Monitoring for Kubernetes or a cloud provider's observability tools to leverage logging, monitoring and alerting capabilties in your Viya platform. |
+| 0210 | [Understand how to Check the Status of Services](tasks/how_to_check_service_status.md) | Ensure you know how to check the status of all SAS Viya services ad hoc at any time |
+| 0220 | [Configure audit record archival](tasks/audit_record_archival.md) | Configure and schedule the archiving of SAS Viya audit records. |
+| 0230 | [Enable job to purge archived audit records](tasks/purge_archived_audit_records.md) | Enable the routine purging of archived audit records from the archive location (PV) |
+| 0240 | [Validate your SAS Viya Deployment](tasks/validate_deployment.md) | Define a set of tests to validate that your SAS Viya deployment is functioning correctly |
+| 0250 | [Define a backup and restore strategy](tasks/backup_and_restore.md) | Define a backup and restore strategy |
+| 0260 | [Know how to Contact SAS Technical Support for Help](tasks/contact_SAS_technical_support.md) | Ensure all SAS platform administration staff know how to contact SAS Technical Support for help |
+| 0270 | [Identify Components of SAS and Third-Party Software](tasks/identify_viya_components.md) | Ensure you can identify the components of SAS and third-party software that make up SAS Viya |
+| 0280 | [Decide approach to applying updates](tasks/decide_update_approach.md) | Decide how and when your SAS Viya software will be updated |
+| 0290 | [Configure SAS Studio Preferences](tasks/configure_sas_studio_preferences.md) | Configure SAS Studio Preferences |
+| 0300 | [Define a Process for Onboarding and Offboarding Users](tasks/process_for_onboarding_and_offboarding_users.md) | Document any steps that must be performed when new users are onboarded and offboarded |
+| 0310 | [Secure the sasboot password](tasks/secure_sasboot_password.md) | Disable the sasboot password reset feature after you have finished setting up identities and initial administrators |
+| 0320 | [Secure Default Caslibs, especially the Public Caslib](tasks/secure_default_caslibs.md) | Review and change default access controls on default CAS libraries |
+| 0330 | [Consider relocating CAS_DISK_CACHE](tasks/relocate_cas_disk_cache.md) | Relocate the CAS_DISK_CACHE for CAS servers |
+| 0340 | [Configure CAS Allowlist](tasks/configure_cas_allowlist.md) | Configure CAS allowlist for user-defined CAS libraries |
+| 0350 | [Configure External Access to CAS](tasks/configure_cas_external_access.md) | Configure access to CAS from outside your SAS Viya deployment |
+| 0360 | [Set location for SAS Work and other Programming Run-Time Temporary Files](tasks/move_sas_work_and_spre_temporary_files_location.md) | Move SAS Work and other Programming Run-Time Temporary Files to a better location than the default |
+| 0370 | [Configure Common Programming Run-Time Autoexec Statements](tasks/common_programming_run-time_options.md) | Configure statements in SAS Programming Run-Time Autoexec code blocks, to set commonly used SAS options for macro programming, performance tuning, use of mail servers and pre-assigning SAS libraries. |
+| 0380 | [Modify Launcher and SAS Programming Run-Time Server Contexts](tasks/modify_programming_launcher_server_contexts.md) | Modify Launcher and Server contexts for SAS Compute Server, SAS Connect Server and SAS Batch Server |
+| 0390 | [Define Library Connection Data Sources as a Resource in SAS Programming Run-Time Contexts](tasks/manage_connections_to_data_sources.md) | Compute, Connect and Batch contexts can be associated with Required Resources, the first of which is a Library Connection. |
+| 0400 | [Configure lockdown for SAS Programming run-time servers](tasks/configure_lockdown.md) | Configure lockdown for SAS Programming Run-Time servers |
+| 0410 | [Configure Programming Allowlist](tasks/configure_programming_allowlist.md) | Configure SAS Programming Run-Time for user-defined paths |
+| 0420 | [Configure umask for SAS Programmning run-time servers](tasks/configure_programming_run-time_umask.md) | Configure umask to e.g. 0002 for SAS Programming Run-Time servers, so that files created by users (including datasets in path-based libraries) are read-write for members of the user's primary POSIX group |
+| 0430 | [Set User Process Limit](tasks/set_user_process_limit.md) | Set the maximum number of launched compute, connect or batch programming run-time pods each user may run simultaneously |
+| 0440 | [Tune the Programming Run-Time](tasks/tune_programming_run-time.md) | Tune the SAS Viya Platform Programming Run-time for better performance with your workload |
+| 0450 | [Design and Maintain a Schedule of SAS Administration Housekeeping Activities](tasks/maintain_housekeeping_schedule.md) | Design and maintain a schedule of SAS Viya platform administration housekeeping activities, specifying when regular tasks should be performed. |
+| 0460 | [Renew your SAS Viya License](tasks/update_licenses.md) | Obtain and apply a new SAS Viya platform license before your existing license expires |
+| 0470 | [Update the SAS Viya CLI](tasks/update_sas_viya_cli.md) | Ensure you have installed the sas-viya cli and its plugins |
+| 0480 | [Renew your OIDC client secret](tasks/renew_oidc_client_secret.md) | If your SAS Viya deployment is configured to use OIDC, renew your OIDC client secret before it expires. |
+| 0490 | [Update External Credentials](tasks/update_external_credentials.md) | When external credentials change, follow your defined process to update them in SAS Viya |
+| 0500 | [Check the Status of SAS services](tasks/check_service_status.md) | Regularly check the status of SAS services |
+| 0510 | [Monitor Memory, CPU, Network, and Disk Throughput Usage](tasks/monitor_usage.md) | Monitor memory usage, CPU usage, network I/O usage, disk throughput usage, input/output operations per second (IOPS), etc |
+| 0520 | [Monitor Log Messages](tasks/monitor_logs.md) | Monitor log messages |
+| 0530 | [Examine the User Activity Report](tasks/examine_user_activity_report.md) | Examine the user activity report |
+| 0540 | [Change log levels](tasks/change_log_levels.md) | Change the log threshold for a SAS component or service, to increase or decrease the detail of log messages it produces |
+| 0550 | [Monitor Storage Space](tasks/monitor_storage_space.md) | Monitor the disk space used for SAS Viya |
+| 0560 | [Monitor Observability Storage](tasks/monitor_observabilty_storage.md) | Monitor the disk or other storage space used for the log and metric monitoring tools, and other observability tools deployed to monitor SAS Viya |
+| 0570 | [Stop and Start SAS Viya's Monitoring and Logging components](tasks/stop_and_start_sas_viya_monitoring_for_kubernetes.md) | Ensure you can stop the logging and monitoring solution and that you can start it back up when needed again. |
+| 0580 | [Onboard and Offboard Users](tasks/onboard_and_offboard_users.md) | Onboard new users and offboard old users |
+| 0590 | [Keep your Software Current](tasks/keep_software_current.md) | Keep your software current with patch and version updates to stay within Standard Support guidelines. |
+| 0600 | [Regularly Re-Validate your SAS Viya Deployment](tasks/validate_deployment_regularly.md) | Run a set of tests to validate that your SAS Viya deployment is functioning correctly |
+| 0610 | [Periodically Run an Inventory Scan on the Viya Environment](tasks/inventory_scan.md) | Periodically Run an Inventory Scan on the Viya Environment |
+| 0620 | [Stop and Start SAS Viya software](tasks/stop_and_start_viya.md) | Ensure you can scale your SAS Viya deployment to zero, and that you can scale it back up when needed again. |
+| 0630 | [Inspect the Status of Scheduled Jobs](tasks/inspect_job_status.md) | Inspect the status of scheduled jobs |
+| 0640 | [Test the Process to Restore From Backups](tasks/test_restore_process.md) | Periodically test the process to restore from backups |
+| 0650 | [Configure CAS server startup to load data](tasks/cas_server_startup.md) | Configure CAS server startup to load data |
+| 0660 | [Monitor Compute Sessions](tasks/monitor_compute_sessions.md) | Use the sas-viya CLI, log and metric monitoring tools to monitor compute sessions |
+| 0670 | [Manage content stored in PostgreSQL](tasks/manage_postgresql_content.md) | Manage content stored in PostgresQL |
+| 0680 | [Maintain SAS Infrastructure Data Server](tasks/maintain_postgresql_server.md) | Perform routine maintenance on the SAS Infrastructure Data Server |
 
 ---
 ---
@@ -131,46 +131,46 @@ These tasks are new in this Checklist for SAS Viya 2020.1 and later. They have n
 
 | # ▴ | Title | Description | Tags |
 |---|---|---|---|
-| 0010 | [Automate your SAS Viya Deployment Process](tasks\automate_environment_creation.md) | Automate the process of creating and configuring your SAS Viya deployment | Initial,New,Done |
-| 0020 | [Install the SAS Viya CLI](tasks\install_sas_viya_cli.md) | Ensure you have installed the sas-viya cli and its plugins. | New,Initial,Done |
-| 0030 | [Develop an update plan](tasks\develop_update_plan.md) | Develop an update plan: outline tasks required before, during and after an update | Initial,New,Done |
-| 0060 | [Load POSIX attributes](tasks\load_posix_attributes.md) | Load POSIX attributes for identities when attributes are not returned from the authentication provider | New,Initial,Done |
-| 0070 | [Create and Configure User home-directories](tasks\createandconfigure_user_homedirs.md) | Create and configure user-home directories | New,Initial,Done |
-| 0100 | [Know when to renew your OIDC client secret](tasks\when_to_renew_oidc_client_secret.md) | Open ID Connect uses expiring client secrets with a maximum lifetime of 2 years. If your SAS Viya deployment is configured to use OIDC, ensure that you know when this client secret expires so that you can renew it before it does. | Initial,New,Done |
-| 0110 | [Configure Open Source Integration](tasks\configure_open_source_integration.md) | Configure open source integration | New,Initial,Done |
-| 0120 | [Review Tuning Recommendations](tasks\tuning_recommendations.md) | Review SAS Viya platform tuning recommendations and apply as needed | New,Initial,Done |
-| 0130 | [Configure CORS and CSRF settings](tasks\configure_cors_and_csrf.md) | Configure the SAS Viya platform's Cross-Origin Resource Sharing (CORS) and Cross-Site Request Forgery (CSRF) settings for deployments behind a DNS alias or proxy, and for SAS Visual Analytics | Initial,New,Done |
-| 0190 | [Select Log & Metric Monitoring and Alerting Solution](tasks\select_monitoring_solution.md) | Choose a log and metric monitoring and alerting solution | Initial,New,Done |
-| 0200 | [Set Up Monitoring and Alerting](tasks\observability_monitoring_and_alerting.md) | Learn how to deploy, update and use either SAS Viya Monitoring for Kubernetes or a cloud provider's observability tools to leverage logging, monitoring and alerting capabilties in your Viya platform. | Initial,New,Done |
-| 0220 | [Configure audit record archival](tasks\audit_record_archival.md) | Configure and schedule the archiving of SAS Viya audit records. | Initial,New,Done |
-| 0230 | [Enable job to purge archived audit records](tasks\purge_archived_audit_records.md) | Enable the routine purging of archived audit records from the archive location (PV) | Initial,New,Done |
-| 0240 | [Validate your SAS Viya Deployment](tasks\validate_deployment.md) | Define a set of tests to validate that your SAS Viya deployment is functioning correctly | Initial,New,Done |
-| 0250 | [Define a backup and restore strategy](tasks\backup_and_restore.md) | Define a backup and restore strategy | Initial,New,Done |
-| 0280 | [Decide approach to applying updates](tasks\decide_update_approach.md) | Decide how and when your SAS Viya software will be updated | Initial,New,Done |
-| 0290 | [Configure SAS Studio Preferences](tasks\configure_sas_studio_preferences.md) | Configure SAS Studio Preferences | New,Initial,Done |
-| 0310 | [Secure the sasboot password](tasks\secure_sasboot_password.md) | Disable the sasboot password reset feature after you have finished setting up identities and initial administrators | Initial,New,Done |
-| 0320 | [Secure Default Caslibs, especially the Public Caslib](tasks\secure_default_caslibs.md) | Review and change default access controls on default CAS libraries | Initial,New,Done |
-| 0330 | [Consider relocating CAS_DISK_CACHE](tasks\relocate_cas_disk_cache.md) | Relocate the CAS_DISK_CACHE for CAS servers | Initial,New,Done |
-| 0340 | [Configure CAS Allowlist](tasks\configure_cas_allowlist.md) | Configure CAS allowlist for user-defined CAS libraries | Initial,New,Done |
-| 0350 | [Configure External Access to CAS](tasks\configure_cas_external_access.md) | Configure access to CAS from outside your SAS Viya deployment | Initial,New,Done |
-| 0370 | [Configure Common Programming Run-Time Autoexec Statements](tasks\common_programming_run-time_options.md) | Configure statements in SAS Programming Run-Time Autoexec code blocks, to set commonly used SAS options for macro programming, performance tuning, use of mail servers and pre-assigning SAS libraries. | Initial,New,Done |
-| 0390 | [Define Library Connection Data Sources as a Resource in SAS Programming Run-Time Contexts](tasks\manage_connections_to_data_sources.md) | Compute, Connect and Batch contexts can be associated with Required Resources, the first of which is a Library Connection. | Initial,New,Done |
-| 0400 | [Configure lockdown for SAS Programming run-time servers](tasks\configure_lockdown.md) | Configure lockdown for SAS Programming Run-Time servers | New,Initial,Done |
-| 0410 | [Configure Programming Allowlist](tasks\configure_programming_allowlist.md) | Configure SAS Programming Run-Time for user-defined paths | Initial,New,Done |
-| 0420 | [Configure umask for SAS Programmning run-time servers](tasks\configure_programming_run-time_umask.md) | Configure umask to e.g. 0002 for SAS Programming Run-Time servers, so that files created by users (including datasets in path-based libraries) are read-write for members of the user's primary POSIX group | New,Initial,Done |
-| 0430 | [Set User Process Limit](tasks\set_user_process_limit.md) | Set the maximum number of launched compute, connect or batch programming run-time pods each user may run simultaneously | Initial,New,Done |
-| 0440 | [Tune the Programming Run-Time](tasks\tune_programming_run-time.md) | Tune the SAS Viya Platform Programming Run-time for better performance with your workload | Initial,New,Done |
-| 0470 | [Update the SAS Viya CLI](tasks\update_sas_viya_cli.md) | Ensure you have installed the sas-viya cli and its plugins | New,Regular,Done |
-| 0480 | [Renew your OIDC client secret](tasks\renew_oidc_client_secret.md) | If your SAS Viya deployment is configured to use OIDC, renew your OIDC client secret before it expires. | Regular,New,Done |
-| 0560 | [Monitor Observability Storage](tasks\monitor_observabilty_storage.md) | Monitor the disk or other storage space used for the log and metric monitoring tools, and other observability tools deployed to monitor SAS Viya | Regular,New,Done |
-| 0570 | [Stop and Start SAS Viya's Monitoring and Logging components](tasks\stop_and_start_sas_viya_monitoring_for_kubernetes.md) | Ensure you can stop the logging and monitoring solution and that you can start it back up when needed again. | Regular,New,Done |
-| 0590 | [Keep your Software Current](tasks\keep_software_current.md) | Keep your software current with patch and version updates to stay within Standard Support guidelines. | Regular,New,Done |
-| 0600 | [Regularly Re-Validate your SAS Viya Deployment](tasks\validate_deployment_regularly.md) | Run a set of tests to validate that your SAS Viya deployment is functioning correctly | Regular,New,Done |
-| 0610 | [Periodically Run an Inventory Scan on the Viya Environment](tasks\inventory_scan.md) | Periodically Run an Inventory Scan on the Viya Environment | New,Regular,Done |
-| 0650 | [Configure CAS server startup to load data](tasks\cas_server_startup.md) | Configure CAS server startup to load data | New,Regular,Done |
-| 0660 | [Monitor Compute Sessions](tasks\monitor_compute_sessions.md) | Use the sas-viya CLI, log and metric monitoring tools to monitor compute sessions | Regular,New,Done |
-| 0670 | [Manage content stored in PostgreSQL](tasks\manage_postgresql_content.md) | Manage content stored in PostgresQL | New,Regular,Done |
-| 0680 | [Maintain SAS Infrastructure Data Server](tasks\maintain_postgresql_server.md) | Perform routine maintenance on the SAS Infrastructure Data Server | New,Regular,Done |
+| 0010 | [Automate your SAS Viya Deployment Process](tasks/automate_environment_creation.md) | Automate the process of creating and configuring your SAS Viya deployment | Initial,New,Done |
+| 0020 | [Install the SAS Viya CLI](tasks/install_sas_viya_cli.md) | Ensure you have installed the sas-viya cli and its plugins. | New,Initial,Done |
+| 0030 | [Develop an update plan](tasks/develop_update_plan.md) | Develop an update plan: outline tasks required before, during and after an update | Initial,New,Done |
+| 0060 | [Load POSIX attributes](tasks/load_posix_attributes.md) | Load POSIX attributes for identities when attributes are not returned from the authentication provider | New,Initial,Done |
+| 0070 | [Create and Configure User home-directories](tasks/createandconfigure_user_homedirs.md) | Create and configure user-home directories | New,Initial,Done |
+| 0100 | [Know when to renew your OIDC client secret](tasks/when_to_renew_oidc_client_secret.md) | Open ID Connect uses expiring client secrets with a maximum lifetime of 2 years. If your SAS Viya deployment is configured to use OIDC, ensure that you know when this client secret expires so that you can renew it before it does. | Initial,New,Done |
+| 0110 | [Configure Open Source Integration](tasks/configure_open_source_integration.md) | Configure open source integration | New,Initial,Done |
+| 0120 | [Review Tuning Recommendations](tasks/tuning_recommendations.md) | Review SAS Viya platform tuning recommendations and apply as needed | New,Initial,Done |
+| 0130 | [Configure CORS and CSRF settings](tasks/configure_cors_and_csrf.md) | Configure the SAS Viya platform's Cross-Origin Resource Sharing (CORS) and Cross-Site Request Forgery (CSRF) settings for deployments behind a DNS alias or proxy, and for SAS Visual Analytics | Initial,New,Done |
+| 0190 | [Select Log & Metric Monitoring and Alerting Solution](tasks/select_monitoring_solution.md) | Choose a log and metric monitoring and alerting solution | Initial,New,Done |
+| 0200 | [Set Up Monitoring and Alerting](tasks/observability_monitoring_and_alerting.md) | Learn how to deploy, update and use either SAS Viya Monitoring for Kubernetes or a cloud provider's observability tools to leverage logging, monitoring and alerting capabilties in your Viya platform. | Initial,New,Done |
+| 0220 | [Configure audit record archival](tasks/audit_record_archival.md) | Configure and schedule the archiving of SAS Viya audit records. | Initial,New,Done |
+| 0230 | [Enable job to purge archived audit records](tasks/purge_archived_audit_records.md) | Enable the routine purging of archived audit records from the archive location (PV) | Initial,New,Done |
+| 0240 | [Validate your SAS Viya Deployment](tasks/validate_deployment.md) | Define a set of tests to validate that your SAS Viya deployment is functioning correctly | Initial,New,Done |
+| 0250 | [Define a backup and restore strategy](tasks/backup_and_restore.md) | Define a backup and restore strategy | Initial,New,Done |
+| 0280 | [Decide approach to applying updates](tasks/decide_update_approach.md) | Decide how and when your SAS Viya software will be updated | Initial,New,Done |
+| 0290 | [Configure SAS Studio Preferences](tasks/configure_sas_studio_preferences.md) | Configure SAS Studio Preferences | New,Initial,Done |
+| 0310 | [Secure the sasboot password](tasks/secure_sasboot_password.md) | Disable the sasboot password reset feature after you have finished setting up identities and initial administrators | Initial,New,Done |
+| 0320 | [Secure Default Caslibs, especially the Public Caslib](tasks/secure_default_caslibs.md) | Review and change default access controls on default CAS libraries | Initial,New,Done |
+| 0330 | [Consider relocating CAS_DISK_CACHE](tasks/relocate_cas_disk_cache.md) | Relocate the CAS_DISK_CACHE for CAS servers | Initial,New,Done |
+| 0340 | [Configure CAS Allowlist](tasks/configure_cas_allowlist.md) | Configure CAS allowlist for user-defined CAS libraries | Initial,New,Done |
+| 0350 | [Configure External Access to CAS](tasks/configure_cas_external_access.md) | Configure access to CAS from outside your SAS Viya deployment | Initial,New,Done |
+| 0370 | [Configure Common Programming Run-Time Autoexec Statements](tasks/common_programming_run-time_options.md) | Configure statements in SAS Programming Run-Time Autoexec code blocks, to set commonly used SAS options for macro programming, performance tuning, use of mail servers and pre-assigning SAS libraries. | Initial,New,Done |
+| 0390 | [Define Library Connection Data Sources as a Resource in SAS Programming Run-Time Contexts](tasks/manage_connections_to_data_sources.md) | Compute, Connect and Batch contexts can be associated with Required Resources, the first of which is a Library Connection. | Initial,New,Done |
+| 0400 | [Configure lockdown for SAS Programming run-time servers](tasks/configure_lockdown.md) | Configure lockdown for SAS Programming Run-Time servers | New,Initial,Done |
+| 0410 | [Configure Programming Allowlist](tasks/configure_programming_allowlist.md) | Configure SAS Programming Run-Time for user-defined paths | Initial,New,Done |
+| 0420 | [Configure umask for SAS Programmning run-time servers](tasks/configure_programming_run-time_umask.md) | Configure umask to e.g. 0002 for SAS Programming Run-Time servers, so that files created by users (including datasets in path-based libraries) are read-write for members of the user's primary POSIX group | New,Initial,Done |
+| 0430 | [Set User Process Limit](tasks/set_user_process_limit.md) | Set the maximum number of launched compute, connect or batch programming run-time pods each user may run simultaneously | Initial,New,Done |
+| 0440 | [Tune the Programming Run-Time](tasks/tune_programming_run-time.md) | Tune the SAS Viya Platform Programming Run-time for better performance with your workload | Initial,New,Done |
+| 0470 | [Update the SAS Viya CLI](tasks/update_sas_viya_cli.md) | Ensure you have installed the sas-viya cli and its plugins | New,Regular,Done |
+| 0480 | [Renew your OIDC client secret](tasks/renew_oidc_client_secret.md) | If your SAS Viya deployment is configured to use OIDC, renew your OIDC client secret before it expires. | Regular,New,Done |
+| 0560 | [Monitor Observability Storage](tasks/monitor_observabilty_storage.md) | Monitor the disk or other storage space used for the log and metric monitoring tools, and other observability tools deployed to monitor SAS Viya | Regular,New,Done |
+| 0570 | [Stop and Start SAS Viya's Monitoring and Logging components](tasks/stop_and_start_sas_viya_monitoring_for_kubernetes.md) | Ensure you can stop the logging and monitoring solution and that you can start it back up when needed again. | Regular,New,Done |
+| 0590 | [Keep your Software Current](tasks/keep_software_current.md) | Keep your software current with patch and version updates to stay within Standard Support guidelines. | Regular,New,Done |
+| 0600 | [Regularly Re-Validate your SAS Viya Deployment](tasks/validate_deployment_regularly.md) | Run a set of tests to validate that your SAS Viya deployment is functioning correctly | Regular,New,Done |
+| 0610 | [Periodically Run an Inventory Scan on the Viya Environment](tasks/inventory_scan.md) | Periodically Run an Inventory Scan on the Viya Environment | New,Regular,Done |
+| 0650 | [Configure CAS server startup to load data](tasks/cas_server_startup.md) | Configure CAS server startup to load data | New,Regular,Done |
+| 0660 | [Monitor Compute Sessions](tasks/monitor_compute_sessions.md) | Use the sas-viya CLI, log and metric monitoring tools to monitor compute sessions | Regular,New,Done |
+| 0670 | [Manage content stored in PostgreSQL](tasks/manage_postgresql_content.md) | Manage content stored in PostgresQL | New,Regular,Done |
+| 0680 | [Maintain SAS Infrastructure Data Server](tasks/maintain_postgresql_server.md) | Perform routine maintenance on the SAS Infrastructure Data Server | New,Regular,Done |
 
 ## Legacy
 
@@ -180,33 +180,33 @@ These tasks are the modern SAS Viya 2020.1 equivalent of an task which also appe
 
 | # ▴ | Title | Description | Tags |
 |---|---|---|---|
-| 0040 | [Maintain a Secure Password Database](tasks\maintain_password_database.md) | Maintain a secure and encrypted password-protected password database using an appropriate software tool or service | Initial,Legacy,Done |
-| 0050 | [Update TLS certificates](tasks\encryption_with_public_ca_signed_tls_certificates.md) | Generate new or renew expiring TLS certificates used for encryption of data in transit. | Initial,Legacy,Done |
-| 0080 | [Ensure You Have Provided Sufficient Storage for Path-Based Caslibs](tasks\ensure_storage_for_caslibs.md) | Ensure you have provided sufficient filesystem storage of an appropriate type for path-based caslibs. | Initial,Legacy,Done |
-| 0090 | [Define a Process for Updating External Credentials](tasks\process_for_updating_external_credentials.md) | Define a when and how you will update credentials that are stored in SAS Viya for external systems such as databases, when they change | Initial,Legacy,Done |
-| 0140 | [Service Level Agreement](tasks\sla.md) | For enterprise-scale deployments, define a Service Level Agreement (SLA) | Initial,Legacy,Done |
-| 0150 | [Define your organizationâ€™s SAS support team structure, roles, and responsibilities](tasks\define_org_support_structure.md) | Define your organizationâ€™s SAS support team structure, roles, and responsibilities | Initial,Legacy,Done |
-| 0160 | [Premium Support](tasks\premium_support.md) | Consider whether you require premium or customized support for your SAS deployment | Initial,Legacy,Done |
-| 0170 | [Security Policy](tasks\security_policy.md) | Write and maintain a security policy that covers the SAS Viya deployment | Initial,Legacy,Done |
-| 0180 | [Authorization Model](tasks\authorization_model.md) | Write and maintain a security model or an authorization model | Initial,Legacy,Done |
-| 0210 | [Understand how to Check the Status of Services](tasks\how_to_check_service_status.md) | Ensure you know how to check the status of all SAS Viya services ad hoc at any time | Initial,Legacy,Done |
-| 0260 | [Know how to Contact SAS Technical Support for Help](tasks\contact_SAS_technical_support.md) | Ensure all SAS platform administration staff know how to contact SAS Technical Support for help | Initial,Legacy,Done |
-| 0270 | [Identify Components of SAS and Third-Party Software](tasks\identify_viya_components.md) | Ensure you can identify the components of SAS and third-party software that make up SAS Viya | Initial,Legacy,Done |
-| 0300 | [Define a Process for Onboarding and Offboarding Users](tasks\process_for_onboarding_and_offboarding_users.md) | Document any steps that must be performed when new users are onboarded and offboarded | Initial,Legacy,Done |
-| 0360 | [Set location for SAS Work and other Programming Run-Time Temporary Files](tasks\move_sas_work_and_spre_temporary_files_location.md) | Move SAS Work and other Programming Run-Time Temporary Files to a better location than the default | Initial,Legacy,Done |
-| 0380 | [Modify Launcher and SAS Programming Run-Time Server Contexts](tasks\modify_programming_launcher_server_contexts.md) | Modify Launcher and Server contexts for SAS Compute Server, SAS Connect Server and SAS Batch Server | Initial,Legacy,Done |
-| 0450 | [Design and Maintain a Schedule of SAS Administration Housekeeping Activities](tasks\maintain_housekeeping_schedule.md) | Design and maintain a schedule of SAS Viya platform administration housekeeping activities, specifying when regular tasks should be performed. | Initial,Legacy,Done |
-| 0460 | [Renew your SAS Viya License](tasks\update_licenses.md) | Obtain and apply a new SAS Viya platform license before your existing license expires | Regular,Legacy,Done |
-| 0490 | [Update External Credentials](tasks\update_external_credentials.md) | When external credentials change, follow your defined process to update them in SAS Viya | Regular,Legacy,Done |
-| 0500 | [Check the Status of SAS services](tasks\check_service_status.md) | Regularly check the status of SAS services | Regular,Legacy,Done |
-| 0510 | [Monitor Memory, CPU, Network, and Disk Throughput Usage](tasks\monitor_usage.md) | Monitor memory usage, CPU usage, network I/O usage, disk throughput usage, input/output operations per second (IOPS), etc | Regular,Legacy,Done |
-| 0520 | [Monitor Log Messages](tasks\monitor_logs.md) | Monitor log messages | Regular,Legacy,Done |
-| 0530 | [Examine the User Activity Report](tasks\examine_user_activity_report.md) | Examine the user activity report | Regular,Legacy,Done |
-| 0540 | [Change log levels](tasks\change_log_levels.md) | Change the log threshold for a SAS component or service, to increase or decrease the detail of log messages it produces | Regular,Legacy,Done |
-| 0550 | [Monitor Storage Space](tasks\monitor_storage_space.md) | Monitor the disk space used for SAS Viya | Regular,Legacy,Done |
-| 0580 | [Onboard and Offboard Users](tasks\onboard_and_offboard_users.md) | Onboard new users and offboard old users | Regular,Legacy,Done |
-| 0620 | [Stop and Start SAS Viya software](tasks\stop_and_start_viya.md) | Ensure you can scale your SAS Viya deployment to zero, and that you can scale it back up when needed again. | Regular,Legacy,Done |
-| 0630 | [Inspect the Status of Scheduled Jobs](tasks\inspect_job_status.md) | Inspect the status of scheduled jobs | Regular,Legacy,Done |
-| 0640 | [Test the Process to Restore From Backups](tasks\test_restore_process.md) | Periodically test the process to restore from backups | Regular,Legacy,Done |
+| 0040 | [Maintain a Secure Password Database](tasks/maintain_password_database.md) | Maintain a secure and encrypted password-protected password database using an appropriate software tool or service | Initial,Legacy,Done |
+| 0050 | [Update TLS certificates](tasks/encryption_with_public_ca_signed_tls_certificates.md) | Generate new or renew expiring TLS certificates used for encryption of data in transit. | Initial,Legacy,Done |
+| 0080 | [Ensure You Have Provided Sufficient Storage for Path-Based Caslibs](tasks/ensure_storage_for_caslibs.md) | Ensure you have provided sufficient filesystem storage of an appropriate type for path-based caslibs. | Initial,Legacy,Done |
+| 0090 | [Define a Process for Updating External Credentials](tasks/process_for_updating_external_credentials.md) | Define a when and how you will update credentials that are stored in SAS Viya for external systems such as databases, when they change | Initial,Legacy,Done |
+| 0140 | [Service Level Agreement](tasks/sla.md) | For enterprise-scale deployments, define a Service Level Agreement (SLA) | Initial,Legacy,Done |
+| 0150 | [Define your organizationâ€™s SAS support team structure, roles, and responsibilities](tasks/define_org_support_structure.md) | Define your organizationâ€™s SAS support team structure, roles, and responsibilities | Initial,Legacy,Done |
+| 0160 | [Premium Support](tasks/premium_support.md) | Consider whether you require premium or customized support for your SAS deployment | Initial,Legacy,Done |
+| 0170 | [Security Policy](tasks/security_policy.md) | Write and maintain a security policy that covers the SAS Viya deployment | Initial,Legacy,Done |
+| 0180 | [Authorization Model](tasks/authorization_model.md) | Write and maintain a security model or an authorization model | Initial,Legacy,Done |
+| 0210 | [Understand how to Check the Status of Services](tasks/how_to_check_service_status.md) | Ensure you know how to check the status of all SAS Viya services ad hoc at any time | Initial,Legacy,Done |
+| 0260 | [Know how to Contact SAS Technical Support for Help](tasks/contact_SAS_technical_support.md) | Ensure all SAS platform administration staff know how to contact SAS Technical Support for help | Initial,Legacy,Done |
+| 0270 | [Identify Components of SAS and Third-Party Software](tasks/identify_viya_components.md) | Ensure you can identify the components of SAS and third-party software that make up SAS Viya | Initial,Legacy,Done |
+| 0300 | [Define a Process for Onboarding and Offboarding Users](tasks/process_for_onboarding_and_offboarding_users.md) | Document any steps that must be performed when new users are onboarded and offboarded | Initial,Legacy,Done |
+| 0360 | [Set location for SAS Work and other Programming Run-Time Temporary Files](tasks/move_sas_work_and_spre_temporary_files_location.md) | Move SAS Work and other Programming Run-Time Temporary Files to a better location than the default | Initial,Legacy,Done |
+| 0380 | [Modify Launcher and SAS Programming Run-Time Server Contexts](tasks/modify_programming_launcher_server_contexts.md) | Modify Launcher and Server contexts for SAS Compute Server, SAS Connect Server and SAS Batch Server | Initial,Legacy,Done |
+| 0450 | [Design and Maintain a Schedule of SAS Administration Housekeeping Activities](tasks/maintain_housekeeping_schedule.md) | Design and maintain a schedule of SAS Viya platform administration housekeeping activities, specifying when regular tasks should be performed. | Initial,Legacy,Done |
+| 0460 | [Renew your SAS Viya License](tasks/update_licenses.md) | Obtain and apply a new SAS Viya platform license before your existing license expires | Regular,Legacy,Done |
+| 0490 | [Update External Credentials](tasks/update_external_credentials.md) | When external credentials change, follow your defined process to update them in SAS Viya | Regular,Legacy,Done |
+| 0500 | [Check the Status of SAS services](tasks/check_service_status.md) | Regularly check the status of SAS services | Regular,Legacy,Done |
+| 0510 | [Monitor Memory, CPU, Network, and Disk Throughput Usage](tasks/monitor_usage.md) | Monitor memory usage, CPU usage, network I/O usage, disk throughput usage, input/output operations per second (IOPS), etc | Regular,Legacy,Done |
+| 0520 | [Monitor Log Messages](tasks/monitor_logs.md) | Monitor log messages | Regular,Legacy,Done |
+| 0530 | [Examine the User Activity Report](tasks/examine_user_activity_report.md) | Examine the user activity report | Regular,Legacy,Done |
+| 0540 | [Change log levels](tasks/change_log_levels.md) | Change the log threshold for a SAS component or service, to increase or decrease the detail of log messages it produces | Regular,Legacy,Done |
+| 0550 | [Monitor Storage Space](tasks/monitor_storage_space.md) | Monitor the disk space used for SAS Viya | Regular,Legacy,Done |
+| 0580 | [Onboard and Offboard Users](tasks/onboard_and_offboard_users.md) | Onboard new users and offboard old users | Regular,Legacy,Done |
+| 0620 | [Stop and Start SAS Viya software](tasks/stop_and_start_viya.md) | Ensure you can scale your SAS Viya deployment to zero, and that you can scale it back up when needed again. | Regular,Legacy,Done |
+| 0630 | [Inspect the Status of Scheduled Jobs](tasks/inspect_job_status.md) | Inspect the status of scheduled jobs | Regular,Legacy,Done |
+| 0640 | [Test the Process to Restore From Backups](tasks/test_restore_process.md) | Periodically test the process to restore from backups | Regular,Legacy,Done |
 
-</br>Generated by build_from_template.py on: 21 Jul 2025 17:28:38.</br>
+</br>Generated by build_from_template.py on: 23 Sep 2025 16:57:26.</br>

--- a/tasks_by_topic.md
+++ b/tasks_by_topic.md
@@ -21,11 +21,11 @@ This alternative form of the main [checklist](./checklist.md) lists tasks groupe
 
 | # ▴ | Title | Description | Frequency |
 |---|---|---|---|
-| 0320 | [Secure Default Caslibs, especially the Public Caslib](tasks\secure_default_caslibs.md) | Review and change default access controls on default CAS libraries |  |
-| 0330 | [Consider relocating CAS_DISK_CACHE](tasks\relocate_cas_disk_cache.md) | Relocate the CAS_DISK_CACHE for CAS servers |  |
-| 0340 | [Configure CAS Allowlist](tasks\configure_cas_allowlist.md) | Configure CAS allowlist for user-defined CAS libraries |  |
-| 0350 | [Configure External Access to CAS](tasks\configure_cas_external_access.md) | Configure access to CAS from outside your SAS Viya deployment |  |
-| 0650 | [Configure CAS server startup to load data](tasks\cas_server_startup.md) | Configure CAS server startup to load data | Monthly |
+| 0320 | [Secure Default Caslibs, especially the Public Caslib](tasks/secure_default_caslibs.md) | Review and change default access controls on default CAS libraries |  |
+| 0330 | [Consider relocating CAS_DISK_CACHE](tasks/relocate_cas_disk_cache.md) | Relocate the CAS_DISK_CACHE for CAS servers |  |
+| 0340 | [Configure CAS Allowlist](tasks/configure_cas_allowlist.md) | Configure CAS allowlist for user-defined CAS libraries |  |
+| 0350 | [Configure External Access to CAS](tasks/configure_cas_external_access.md) | Configure access to CAS from outside your SAS Viya deployment |  |
+| 0650 | [Configure CAS server startup to load data](tasks/cas_server_startup.md) | Configure CAS server startup to load data | Monthly |
 
 ## Kubernetes & IT Admin
 
@@ -33,23 +33,23 @@ This alternative form of the main [checklist](./checklist.md) lists tasks groupe
 
 | # ▴ | Title | Description | Frequency |
 |---|---|---|---|
-| 0010 | [Automate your SAS Viya Deployment Process](tasks\automate_environment_creation.md) | Automate the process of creating and configuring your SAS Viya deployment |  |
-| 0020 | [Install the SAS Viya CLI](tasks\install_sas_viya_cli.md) | Ensure you have installed the sas-viya cli and its plugins. |  |
-| 0030 | [Develop an update plan](tasks\develop_update_plan.md) | Develop an update plan: outline tasks required before, during and after an update |  |
-| 0040 | [Maintain a Secure Password Database](tasks\maintain_password_database.md) | Maintain a secure and encrypted password-protected password database using an appropriate software tool or service |  |
-| 0050 | [Update TLS certificates](tasks\encryption_with_public_ca_signed_tls_certificates.md) | Generate new or renew expiring TLS certificates used for encryption of data in transit. |  |
-| 0060 | [Load POSIX attributes](tasks\load_posix_attributes.md) | Load POSIX attributes for identities when attributes are not returned from the authentication provider |  |
-| 0070 | [Create and Configure User home-directories](tasks\createandconfigure_user_homedirs.md) | Create and configure user-home directories |  |
-| 0080 | [Ensure You Have Provided Sufficient Storage for Path-Based Caslibs](tasks\ensure_storage_for_caslibs.md) | Ensure you have provided sufficient filesystem storage of an appropriate type for path-based caslibs. |  |
-| 0090 | [Define a Process for Updating External Credentials](tasks\process_for_updating_external_credentials.md) | Define a when and how you will update credentials that are stored in SAS Viya for external systems such as databases, when they change |  |
-| 0100 | [Know when to renew your OIDC client secret](tasks\when_to_renew_oidc_client_secret.md) | Open ID Connect uses expiring client secrets with a maximum lifetime of 2 years. If your SAS Viya deployment is configured to use OIDC, ensure that you know when this client secret expires so that you can renew it before it does. |  |
-| 0110 | [Configure Open Source Integration](tasks\configure_open_source_integration.md) | Configure open source integration |  |
-| 0120 | [Review Tuning Recommendations](tasks\tuning_recommendations.md) | Review SAS Viya platform tuning recommendations and apply as needed |  |
-| 0130 | [Configure CORS and CSRF settings](tasks\configure_cors_and_csrf.md) | Configure the SAS Viya platform's Cross-Origin Resource Sharing (CORS) and Cross-Site Request Forgery (CSRF) settings for deployments behind a DNS alias or proxy, and for SAS Visual Analytics |  |
-| 0460 | [Renew your SAS Viya License](tasks\update_licenses.md) | Obtain and apply a new SAS Viya platform license before your existing license expires | Annually |
-| 0470 | [Update the SAS Viya CLI](tasks\update_sas_viya_cli.md) | Ensure you have installed the sas-viya cli and its plugins | Quarterly |
-| 0480 | [Renew your OIDC client secret](tasks\renew_oidc_client_secret.md) | If your SAS Viya deployment is configured to use OIDC, renew your OIDC client secret before it expires. | When secret changes |
-| 0490 | [Update External Credentials](tasks\update_external_credentials.md) | When external credentials change, follow your defined process to update them in SAS Viya | When credentials change |
+| 0010 | [Automate your SAS Viya Deployment Process](tasks/automate_environment_creation.md) | Automate the process of creating and configuring your SAS Viya deployment |  |
+| 0020 | [Install the SAS Viya CLI](tasks/install_sas_viya_cli.md) | Ensure you have installed the sas-viya cli and its plugins. |  |
+| 0030 | [Develop an update plan](tasks/develop_update_plan.md) | Develop an update plan: outline tasks required before, during and after an update |  |
+| 0040 | [Maintain a Secure Password Database](tasks/maintain_password_database.md) | Maintain a secure and encrypted password-protected password database using an appropriate software tool or service |  |
+| 0050 | [Update TLS certificates](tasks/encryption_with_public_ca_signed_tls_certificates.md) | Generate new or renew expiring TLS certificates used for encryption of data in transit. |  |
+| 0060 | [Load POSIX attributes](tasks/load_posix_attributes.md) | Load POSIX attributes for identities when attributes are not returned from the authentication provider |  |
+| 0070 | [Create and Configure User home-directories](tasks/createandconfigure_user_homedirs.md) | Create and configure user-home directories |  |
+| 0080 | [Ensure You Have Provided Sufficient Storage for Path-Based Caslibs](tasks/ensure_storage_for_caslibs.md) | Ensure you have provided sufficient filesystem storage of an appropriate type for path-based caslibs. |  |
+| 0090 | [Define a Process for Updating External Credentials](tasks/process_for_updating_external_credentials.md) | Define a when and how you will update credentials that are stored in SAS Viya for external systems such as databases, when they change |  |
+| 0100 | [Know when to renew your OIDC client secret](tasks/when_to_renew_oidc_client_secret.md) | Open ID Connect uses expiring client secrets with a maximum lifetime of 2 years. If your SAS Viya deployment is configured to use OIDC, ensure that you know when this client secret expires so that you can renew it before it does. |  |
+| 0110 | [Configure Open Source Integration](tasks/configure_open_source_integration.md) | Configure open source integration |  |
+| 0120 | [Review Tuning Recommendations](tasks/tuning_recommendations.md) | Review SAS Viya platform tuning recommendations and apply as needed |  |
+| 0130 | [Configure CORS and CSRF settings](tasks/configure_cors_and_csrf.md) | Configure the SAS Viya platform's Cross-Origin Resource Sharing (CORS) and Cross-Site Request Forgery (CSRF) settings for deployments behind a DNS alias or proxy, and for SAS Visual Analytics |  |
+| 0460 | [Renew your SAS Viya License](tasks/update_licenses.md) | Obtain and apply a new SAS Viya platform license before your existing license expires | Annually |
+| 0470 | [Update the SAS Viya CLI](tasks/update_sas_viya_cli.md) | Ensure you have installed the sas-viya cli and its plugins | Quarterly |
+| 0480 | [Renew your OIDC client secret](tasks/renew_oidc_client_secret.md) | If your SAS Viya deployment is configured to use OIDC, renew your OIDC client secret before it expires. | When secret changes |
+| 0490 | [Update External Credentials](tasks/update_external_credentials.md) | When external credentials change, follow your defined process to update them in SAS Viya | When credentials change |
 
 ## Observability
 
@@ -57,19 +57,19 @@ This alternative form of the main [checklist](./checklist.md) lists tasks groupe
 
 | # ▴ | Title | Description | Frequency |
 |---|---|---|---|
-| 0190 | [Select Log & Metric Monitoring and Alerting Solution](tasks\select_monitoring_solution.md) | Choose a log and metric monitoring and alerting solution |  |
-| 0200 | [Set Up Monitoring and Alerting](tasks\observability_monitoring_and_alerting.md) | Learn how to deploy, update and use either SAS Viya Monitoring for Kubernetes or a cloud provider's observability tools to leverage logging, monitoring and alerting capabilties in your Viya platform. |  |
-| 0210 | [Understand how to Check the Status of Services](tasks\how_to_check_service_status.md) | Ensure you know how to check the status of all SAS Viya services ad hoc at any time |  |
-| 0220 | [Configure audit record archival](tasks\audit_record_archival.md) | Configure and schedule the archiving of SAS Viya audit records. |  |
-| 0230 | [Enable job to purge archived audit records](tasks\purge_archived_audit_records.md) | Enable the routine purging of archived audit records from the archive location (PV) |  |
-| 0500 | [Check the Status of SAS services](tasks\check_service_status.md) | Regularly check the status of SAS services | Daily |
-| 0510 | [Monitor Memory, CPU, Network, and Disk Throughput Usage](tasks\monitor_usage.md) | Monitor memory usage, CPU usage, network I/O usage, disk throughput usage, input/output operations per second (IOPS), etc | Daily |
-| 0520 | [Monitor Log Messages](tasks\monitor_logs.md) | Monitor log messages | Daily |
-| 0530 | [Examine the User Activity Report](tasks\examine_user_activity_report.md) | Examine the user activity report | Weekly |
-| 0540 | [Change log levels](tasks\change_log_levels.md) | Change the log threshold for a SAS component or service, to increase or decrease the detail of log messages it produces | When troubleshooting |
-| 0550 | [Monitor Storage Space](tasks\monitor_storage_space.md) | Monitor the disk space used for SAS Viya | Weekly |
-| 0560 | [Monitor Observability Storage](tasks\monitor_observabilty_storage.md) | Monitor the disk or other storage space used for the log and metric monitoring tools, and other observability tools deployed to monitor SAS Viya | Weekly |
-| 0570 | [Stop and Start SAS Viya's Monitoring and Logging components](tasks\stop_and_start_sas_viya_monitoring_for_kubernetes.md) | Ensure you can stop the logging and monitoring solution and that you can start it back up when needed again. | When not in use |
+| 0190 | [Select Log & Metric Monitoring and Alerting Solution](tasks/select_monitoring_solution.md) | Choose a log and metric monitoring and alerting solution |  |
+| 0200 | [Set Up Monitoring and Alerting](tasks/observability_monitoring_and_alerting.md) | Learn how to deploy, update and use either SAS Viya Monitoring for Kubernetes or a cloud provider's observability tools to leverage logging, monitoring and alerting capabilties in your Viya platform. |  |
+| 0210 | [Understand how to Check the Status of Services](tasks/how_to_check_service_status.md) | Ensure you know how to check the status of all SAS Viya services ad hoc at any time |  |
+| 0220 | [Configure audit record archival](tasks/audit_record_archival.md) | Configure and schedule the archiving of SAS Viya audit records. |  |
+| 0230 | [Enable job to purge archived audit records](tasks/purge_archived_audit_records.md) | Enable the routine purging of archived audit records from the archive location (PV) |  |
+| 0500 | [Check the Status of SAS services](tasks/check_service_status.md) | Regularly check the status of SAS services | Daily |
+| 0510 | [Monitor Memory, CPU, Network, and Disk Throughput Usage](tasks/monitor_usage.md) | Monitor memory usage, CPU usage, network I/O usage, disk throughput usage, input/output operations per second (IOPS), etc | Daily |
+| 0520 | [Monitor Log Messages](tasks/monitor_logs.md) | Monitor log messages | Daily |
+| 0530 | [Examine the User Activity Report](tasks/examine_user_activity_report.md) | Examine the user activity report | Weekly |
+| 0540 | [Change log levels](tasks/change_log_levels.md) | Change the log threshold for a SAS component or service, to increase or decrease the detail of log messages it produces | When troubleshooting |
+| 0550 | [Monitor Storage Space](tasks/monitor_storage_space.md) | Monitor the disk space used for SAS Viya | Weekly |
+| 0560 | [Monitor Observability Storage](tasks/monitor_observabilty_storage.md) | Monitor the disk or other storage space used for the log and metric monitoring tools, and other observability tools deployed to monitor SAS Viya | Weekly |
+| 0570 | [Stop and Start SAS Viya's Monitoring and Logging components](tasks/stop_and_start_sas_viya_monitoring_for_kubernetes.md) | Ensure you can stop the logging and monitoring solution and that you can start it back up when needed again. | When not in use |
 
 ## Organization & Governance
 
@@ -77,11 +77,11 @@ This alternative form of the main [checklist](./checklist.md) lists tasks groupe
 
 | # ▴ | Title | Description | Frequency |
 |---|---|---|---|
-| 0140 | [Service Level Agreement](tasks\sla.md) | For enterprise-scale deployments, define a Service Level Agreement (SLA) |  |
-| 0150 | [Define your organizationâ€™s SAS support team structure, roles, and responsibilities](tasks\define_org_support_structure.md) | Define your organizationâ€™s SAS support team structure, roles, and responsibilities |  |
-| 0160 | [Premium Support](tasks\premium_support.md) | Consider whether you require premium or customized support for your SAS deployment |  |
-| 0170 | [Security Policy](tasks\security_policy.md) | Write and maintain a security policy that covers the SAS Viya deployment |  |
-| 0180 | [Authorization Model](tasks\authorization_model.md) | Write and maintain a security model or an authorization model |  |
+| 0140 | [Service Level Agreement](tasks/sla.md) | For enterprise-scale deployments, define a Service Level Agreement (SLA) |  |
+| 0150 | [Define your organizationâ€™s SAS support team structure, roles, and responsibilities](tasks/define_org_support_structure.md) | Define your organizationâ€™s SAS support team structure, roles, and responsibilities |  |
+| 0160 | [Premium Support](tasks/premium_support.md) | Consider whether you require premium or customized support for your SAS deployment |  |
+| 0170 | [Security Policy](tasks/security_policy.md) | Write and maintain a security policy that covers the SAS Viya deployment |  |
+| 0180 | [Authorization Model](tasks/authorization_model.md) | Write and maintain a security model or an authorization model |  |
 
 ## PostgreSQL
 
@@ -89,8 +89,8 @@ This alternative form of the main [checklist](./checklist.md) lists tasks groupe
 
 | # ▴ | Title | Description | Frequency |
 |---|---|---|---|
-| 0670 | [Manage content stored in PostgreSQL](tasks\manage_postgresql_content.md) | Manage content stored in PostgresQL | Monthly |
-| 0680 | [Maintain SAS Infrastructure Data Server](tasks\maintain_postgresql_server.md) | Perform routine maintenance on the SAS Infrastructure Data Server | Monthly |
+| 0670 | [Manage content stored in PostgreSQL](tasks/manage_postgresql_content.md) | Manage content stored in PostgresQL | Monthly |
+| 0680 | [Maintain SAS Infrastructure Data Server](tasks/maintain_postgresql_server.md) | Perform routine maintenance on the SAS Infrastructure Data Server | Monthly |
 
 ## SAS Administration
 
@@ -98,22 +98,22 @@ This alternative form of the main [checklist](./checklist.md) lists tasks groupe
 
 | # ▴ | Title | Description | Frequency |
 |---|---|---|---|
-| 0240 | [Validate your SAS Viya Deployment](tasks\validate_deployment.md) | Define a set of tests to validate that your SAS Viya deployment is functioning correctly |  |
-| 0250 | [Define a backup and restore strategy](tasks\backup_and_restore.md) | Define a backup and restore strategy |  |
-| 0260 | [Know how to Contact SAS Technical Support for Help](tasks\contact_SAS_technical_support.md) | Ensure all SAS platform administration staff know how to contact SAS Technical Support for help |  |
-| 0270 | [Identify Components of SAS and Third-Party Software](tasks\identify_viya_components.md) | Ensure you can identify the components of SAS and third-party software that make up SAS Viya |  |
-| 0280 | [Decide approach to applying updates](tasks\decide_update_approach.md) | Decide how and when your SAS Viya software will be updated |  |
-| 0290 | [Configure SAS Studio Preferences](tasks\configure_sas_studio_preferences.md) | Configure SAS Studio Preferences |  |
-| 0300 | [Define a Process for Onboarding and Offboarding Users](tasks\process_for_onboarding_and_offboarding_users.md) | Document any steps that must be performed when new users are onboarded and offboarded |  |
-| 0310 | [Secure the sasboot password](tasks\secure_sasboot_password.md) | Disable the sasboot password reset feature after you have finished setting up identities and initial administrators |  |
-| 0450 | [Design and Maintain a Schedule of SAS Administration Housekeeping Activities](tasks\maintain_housekeeping_schedule.md) | Design and maintain a schedule of SAS Viya platform administration housekeeping activities, specifying when regular tasks should be performed. |  |
-| 0580 | [Onboard and Offboard Users](tasks\onboard_and_offboard_users.md) | Onboard new users and offboard old users | Weekly |
-| 0590 | [Keep your Software Current](tasks\keep_software_current.md) | Keep your software current with patch and version updates to stay within Standard Support guidelines. | Monthly |
-| 0600 | [Regularly Re-Validate your SAS Viya Deployment](tasks\validate_deployment_regularly.md) | Run a set of tests to validate that your SAS Viya deployment is functioning correctly | Weekly |
-| 0610 | [Periodically Run an Inventory Scan on the Viya Environment](tasks\inventory_scan.md) | Periodically Run an Inventory Scan on the Viya Environment | Monthly |
-| 0620 | [Stop and Start SAS Viya software](tasks\stop_and_start_viya.md) | Ensure you can scale your SAS Viya deployment to zero, and that you can scale it back up when needed again. | When not in use |
-| 0630 | [Inspect the Status of Scheduled Jobs](tasks\inspect_job_status.md) | Inspect the status of scheduled jobs | Daily |
-| 0640 | [Test the Process to Restore From Backups](tasks\test_restore_process.md) | Periodically test the process to restore from backups | Monthly |
+| 0240 | [Validate your SAS Viya Deployment](tasks/validate_deployment.md) | Define a set of tests to validate that your SAS Viya deployment is functioning correctly |  |
+| 0250 | [Define a backup and restore strategy](tasks/backup_and_restore.md) | Define a backup and restore strategy |  |
+| 0260 | [Know how to Contact SAS Technical Support for Help](tasks/contact_SAS_technical_support.md) | Ensure all SAS platform administration staff know how to contact SAS Technical Support for help |  |
+| 0270 | [Identify Components of SAS and Third-Party Software](tasks/identify_viya_components.md) | Ensure you can identify the components of SAS and third-party software that make up SAS Viya |  |
+| 0280 | [Decide approach to applying updates](tasks/decide_update_approach.md) | Decide how and when your SAS Viya software will be updated |  |
+| 0290 | [Configure SAS Studio Preferences](tasks/configure_sas_studio_preferences.md) | Configure SAS Studio Preferences |  |
+| 0300 | [Define a Process for Onboarding and Offboarding Users](tasks/process_for_onboarding_and_offboarding_users.md) | Document any steps that must be performed when new users are onboarded and offboarded |  |
+| 0310 | [Secure the sasboot password](tasks/secure_sasboot_password.md) | Disable the sasboot password reset feature after you have finished setting up identities and initial administrators |  |
+| 0450 | [Design and Maintain a Schedule of SAS Administration Housekeeping Activities](tasks/maintain_housekeeping_schedule.md) | Design and maintain a schedule of SAS Viya platform administration housekeeping activities, specifying when regular tasks should be performed. |  |
+| 0580 | [Onboard and Offboard Users](tasks/onboard_and_offboard_users.md) | Onboard new users and offboard old users | Weekly |
+| 0590 | [Keep your Software Current](tasks/keep_software_current.md) | Keep your software current with patch and version updates to stay within Standard Support guidelines. | Monthly |
+| 0600 | [Regularly Re-Validate your SAS Viya Deployment](tasks/validate_deployment_regularly.md) | Run a set of tests to validate that your SAS Viya deployment is functioning correctly | Weekly |
+| 0610 | [Periodically Run an Inventory Scan on the Viya Environment](tasks/inventory_scan.md) | Periodically Run an Inventory Scan on the Viya Environment | Monthly |
+| 0620 | [Stop and Start SAS Viya software](tasks/stop_and_start_viya.md) | Ensure you can scale your SAS Viya deployment to zero, and that you can scale it back up when needed again. | When not in use |
+| 0630 | [Inspect the Status of Scheduled Jobs](tasks/inspect_job_status.md) | Inspect the status of scheduled jobs | Daily |
+| 0640 | [Test the Process to Restore From Backups](tasks/test_restore_process.md) | Periodically test the process to restore from backups | Monthly |
 
 ## SAS Programming Run-time
 
@@ -121,15 +121,15 @@ This alternative form of the main [checklist](./checklist.md) lists tasks groupe
 
 | # ▴ | Title | Description | Frequency |
 |---|---|---|---|
-| 0360 | [Set location for SAS Work and other Programming Run-Time Temporary Files](tasks\move_sas_work_and_spre_temporary_files_location.md) | Move SAS Work and other Programming Run-Time Temporary Files to a better location than the default |  |
-| 0370 | [Configure Common Programming Run-Time Autoexec Statements](tasks\common_programming_run-time_options.md) | Configure statements in SAS Programming Run-Time Autoexec code blocks, to set commonly used SAS options for macro programming, performance tuning, use of mail servers and pre-assigning SAS libraries. |  |
-| 0380 | [Modify Launcher and SAS Programming Run-Time Server Contexts](tasks\modify_programming_launcher_server_contexts.md) | Modify Launcher and Server contexts for SAS Compute Server, SAS Connect Server and SAS Batch Server |  |
-| 0390 | [Define Library Connection Data Sources as a Resource in SAS Programming Run-Time Contexts](tasks\manage_connections_to_data_sources.md) | Compute, Connect and Batch contexts can be associated with Required Resources, the first of which is a Library Connection. |  |
-| 0400 | [Configure lockdown for SAS Programming run-time servers](tasks\configure_lockdown.md) | Configure lockdown for SAS Programming Run-Time servers |  |
-| 0410 | [Configure Programming Allowlist](tasks\configure_programming_allowlist.md) | Configure SAS Programming Run-Time for user-defined paths |  |
-| 0420 | [Configure umask for SAS Programmning run-time servers](tasks\configure_programming_run-time_umask.md) | Configure umask to e.g. 0002 for SAS Programming Run-Time servers, so that files created by users (including datasets in path-based libraries) are read-write for members of the user's primary POSIX group |  |
-| 0430 | [Set User Process Limit](tasks\set_user_process_limit.md) | Set the maximum number of launched compute, connect or batch programming run-time pods each user may run simultaneously |  |
-| 0440 | [Tune the Programming Run-Time](tasks\tune_programming_run-time.md) | Tune the SAS Viya Platform Programming Run-time for better performance with your workload |  |
-| 0660 | [Monitor Compute Sessions](tasks\monitor_compute_sessions.md) | Use the sas-viya CLI, log and metric monitoring tools to monitor compute sessions | Daily or as often as necessary |
+| 0360 | [Set location for SAS Work and other Programming Run-Time Temporary Files](tasks/move_sas_work_and_spre_temporary_files_location.md) | Move SAS Work and other Programming Run-Time Temporary Files to a better location than the default |  |
+| 0370 | [Configure Common Programming Run-Time Autoexec Statements](tasks/common_programming_run-time_options.md) | Configure statements in SAS Programming Run-Time Autoexec code blocks, to set commonly used SAS options for macro programming, performance tuning, use of mail servers and pre-assigning SAS libraries. |  |
+| 0380 | [Modify Launcher and SAS Programming Run-Time Server Contexts](tasks/modify_programming_launcher_server_contexts.md) | Modify Launcher and Server contexts for SAS Compute Server, SAS Connect Server and SAS Batch Server |  |
+| 0390 | [Define Library Connection Data Sources as a Resource in SAS Programming Run-Time Contexts](tasks/manage_connections_to_data_sources.md) | Compute, Connect and Batch contexts can be associated with Required Resources, the first of which is a Library Connection. |  |
+| 0400 | [Configure lockdown for SAS Programming run-time servers](tasks/configure_lockdown.md) | Configure lockdown for SAS Programming Run-Time servers |  |
+| 0410 | [Configure Programming Allowlist](tasks/configure_programming_allowlist.md) | Configure SAS Programming Run-Time for user-defined paths |  |
+| 0420 | [Configure umask for SAS Programmning run-time servers](tasks/configure_programming_run-time_umask.md) | Configure umask to e.g. 0002 for SAS Programming Run-Time servers, so that files created by users (including datasets in path-based libraries) are read-write for members of the user's primary POSIX group |  |
+| 0430 | [Set User Process Limit](tasks/set_user_process_limit.md) | Set the maximum number of launched compute, connect or batch programming run-time pods each user may run simultaneously |  |
+| 0440 | [Tune the Programming Run-Time](tasks/tune_programming_run-time.md) | Tune the SAS Viya Platform Programming Run-time for better performance with your workload |  |
+| 0660 | [Monitor Compute Sessions](tasks/monitor_compute_sessions.md) | Use the sas-viya CLI, log and metric monitoring tools to monitor compute sessions | Daily or as often as necessary |
 
-</br>Generated by build_from_template.py on: 21 Jul 2025 17:28:39.</br>
+</br>Generated by build_from_template.py on: 23 Sep 2025 16:57:26.</br>


### PR DESCRIPTION
It looks like GitHub stopped automatically converting backslashes in Markdown URL links in the form [text to display](https://github.com/sassoftware/viya4-admin-checklist/pull/path%5Cto%5Cfile.md) to forward slashes in the rendered HTML: [text to display](https://basename/.../path/to/file.md). To fix this, rather than using 'join' to concatenate strings in scripts/checklistsharedfunctions.py, I'm explicitly appending them together with a hardcoded separator "/".

(I also looked at "/".join(a,b) which the docs say should work and is more 'pythonic', but it errored for me, since the number of path elements is always two in this program, it was simpler to hardcode a + "/" + b in this case than it would have been to figure out why, for a script we run a handful of times every few months and which takes a handful of seconds to run in its entirety on a mid-spec laptop!)

All the checklist links should work now.